### PR TITLE
Error improvements

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
     "fs-extra": "^5.0.0",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
+    "websocket": "^1.0.26"
   }
 }

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -78,6 +78,7 @@
 
     <div class="tubeMapSVG">
       <div id="loader" style="display:none;"></div>
+      <div id="inputError"></div>
       <svg id="svg">
       </svg>
     </div>

--- a/frontend/app/scripts/main.js
+++ b/frontend/app/scripts/main.js
@@ -181,12 +181,12 @@ function getRemoteTubeMapData() {
         // We did not get back a graph, only (possibly) an error.
         
         // display error message if any
-        document.getElementById('inputError').innerHTML = response.error;
+        document.getElementById('inputError').innerText = response.error;
         // when there is an error hide the loader
         document.getElementById('loader').style.display = 'none';
       } else {
         // We did get back a graph. We may also have stderr text from vg, but we ignore it.
-        document.getElementById('inputError').innerHTML = '';
+        document.getElementById('inputError').innerText = '';
         // otherwise extract the nodes, tracks, and reads from the response
         const nodes = tubeMap.vgExtractNodes(response.graph);
         const tracks = tubeMap.vgExtractTracks(response.graph);

--- a/frontend/app/scripts/main.js
+++ b/frontend/app/scripts/main.js
@@ -176,15 +176,21 @@ function getRemoteTubeMapData() {
     data: { nodeID, distance, byNode, xgFile, gbwtFile, gamIndex, anchorTrackName, useMountedPath },
     dataType: 'json',
     success(response) {
-      if ($.isEmptyObject(response)) {
-        console.log('empty');
+      // execute when the client recieves a response
+      if (response.error != '') {
+        // display error message if any
+        document.getElementById('inputError').innerHTML = response.error;
+        // when there is an error hide the loader
         document.getElementById('loader').style.display = 'none';
-        return;
+      } else {
+        document.getElementById('inputError').innerHTML = '';
+        // otherwise extract the nodes, tracks, and reads from the response
+        const nodes = tubeMap.vgExtractNodes(response.graph);
+        const tracks = tubeMap.vgExtractTracks(response.graph);
+        const reads = tubeMap.vgExtractReads(nodes, tracks, response.gam);
+        // create the tube map from extracted data
+        createTubeMap(nodes, tracks, reads);
       }
-      const nodes = tubeMap.vgExtractNodes(response.graph);
-      const tracks = tubeMap.vgExtractTracks(response.graph);
-      const reads = tubeMap.vgExtractReads(nodes, tracks, response.gam);
-      createTubeMap(nodes, tracks, reads);
     },
     error(responseData, textStatus, errorThrown) {
       console.log('POST failed.');

--- a/frontend/app/scripts/main.js
+++ b/frontend/app/scripts/main.js
@@ -177,12 +177,15 @@ function getRemoteTubeMapData() {
     dataType: 'json',
     success(response) {
       // execute when the client recieves a response
-      if (response.error != '') {
+      if (response.graph === undefined) {
+        // We did not get back a graph, only (possibly) an error.
+        
         // display error message if any
         document.getElementById('inputError').innerHTML = response.error;
         // when there is an error hide the loader
         document.getElementById('loader').style.display = 'none';
       } else {
+        // We did get back a graph. We may also have stderr text from vg, but we ignore it.
         document.getElementById('inputError').innerHTML = '';
         // otherwise extract the nodes, tracks, and reads from the response
         const nodes = tubeMap.vgExtractNodes(response.graph);


### PR DESCRIPTION
This includes a couple patches on top of #51 to make it work right on my installation.

- I added the "websockets" module to the package.json. @tanessav When you depend on a new module, you need to put it in the package.json so it will get installed; `npm install --save whatever-module` in the backend or frontend directory is the right way to do this.

- I changed the frontend error detection to check if the graph was sent, rather than if an error message was sent. Sometimes vg sends warnings to standard error (in my case, messages about my xg index being in an old and slow format) but works anyway. This way, you can still see the graph even when there are warnings.

- I changed innerHTML to innerText, because if you put raw text in innerHTML it gets parsed as HTML as part of the page, which isn't generally what you want.