### PR TITLE
Deselecting "Show sequence reads" breaks IVG completely

### DIFF
--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -383,6 +383,13 @@ function createTubeMap() {
     generateTrackIndexSequences(reads);
     placeReads();
     tracks = tracks.concat(reads);
+    // we do not have any reads to display
+  } else {
+    nodes.forEach(node => {
+      node.incomingReads = [];
+      node.outgoingReads = [];
+      node.internalReads = [];
+    });
   }
 
   generateSVGShapesFromPath(nodes, tracks);


### PR DESCRIPTION
This commit fixes the issues with the displaying of reads described in #78 .