### PR TITLE
Configure and describe dev mode with the React dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using vg and want visualize the graphs it generates, the online versi
 
 (Previously we provided a docker image at [https://hub.docker.com/r/wolfib/sequencetubemap/](https://hub.docker.com/r/wolfib/sequencetubemap/), which contained the build of this repo as well as a vg executable for data preprocessing and extraction. We now recommend a different installation approach.)
 
-#### Prerequisites:
+#### Prerequisites
 
 yarn or npm, nodejs, and [vg](https://github.com/vgteam/vg) (vg can be tricky to compile. If you run into problems, there are docker images for vg at [https://github.com/vgteam/vg_docker](https://github.com/vgteam/vg_docker).)
 
@@ -59,7 +59,7 @@ The directory containing the vg executable needs to be added to your environment
 PATH=/<your_path_to_vg>:$PATH
 ```
 
-#### Installation:
+#### Installation
 
 - Clone the repo:
   ```
@@ -83,7 +83,7 @@ PATH=/<your_path_to_vg>:$PATH
   npm run build
   ```
 
-#### Execution:
+#### Execution
 
 - Start the node server:
   ```
@@ -101,7 +101,7 @@ PATH=/<your_path_to_vg>:$PATH
 ssh -N -L 3000:localhost:3000 <your username>@<your server>
 ```
 
-#### Adding your own data:
+#### Adding Your Own Data
 
 - The vg files you want to visualize need to contain haplotype/path info. Generating visualizations for the graph itself only is not supported. In addition to the haplotype graph, you can optionally visualize aligned reads from a gam file.
 - Your data needs to be indexed by vg. To generate an index of your vg file, go to the `sequenceTubeMap/scripts/` directory and run
@@ -121,6 +121,20 @@ ssh -N -L 3000:localhost:3000 <your username>@<your server>
   ```
   If you want to use a relative path, this path should be relative to the `sequenceTubeMaps/` folder.
 - restart the server and choose `custom (mounted files)` from the data dropdown in the UI to be able to pick from the files in your data folder.
+
+#### Development Mode
+
+The `build`/`serve` pipeline can only produce minified code, which can be difficult to debug. In development, you should instead use:
+  ```
+  yarn start
+  ```
+  or
+  ```
+  npm run start
+  ```
+This will use React's development mode server to serve the frontend, and run the backend in a separate process, behind React's proxy. Local ports 3000 and 3001 must both be free.
+
+Running in this mode allows the application to produce human-readable stack traces when something goes wrong in the browser.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "body-parser": "^1.19.0",
     "bootstrap": "4.3.1",
     "compression": "^1.7.4",
+    "concurrently": "^6.0.0",
     "d3": "^5.9.2",
     "d3-selection-multi": "^1.0.1",
     "express": "^4.17.1",
@@ -24,7 +25,7 @@
     "websocket": "^1.0.26"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "concurrently -n frontend,backend -c red,green 'PORT=3001 react-scripts start' 'npm:serve'",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
@@ -32,6 +33,7 @@
     "deploy": "gh-pages -d build",
     "serve": "node ./src/server.js"
   },
+  "proxy": "http://localhost:3000",
   "eslintConfig": {
     "extends": "react-app"
   },


### PR DESCRIPTION
Without this, we can't see what's going on when the frontend throws anything.

With it, we get nice stack traces rendered by React into the page for us, when using `npm run start`:

![image](https://user-images.githubusercontent.com/5062495/109547520-4fe8ee00-7a80-11eb-8db9-679e334a808d.png)

This will fix #107.
