### PR TITLE
Add prop types and pass backend URL to file upload form

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "fs-extra": "^8.0.1",
     "gh-pages": "^2.0.1",
     "multer": "^1.3.1",
+    "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import './App.css';
 import HeaderForm from './components/HeaderForm';
 import TubeMapContainer from './components/TubeMapContainer';
@@ -119,6 +120,10 @@ class App extends Component {
       </div>
     );
   }
+}
+
+App.propTypes = {
+  backendUrl: PropTypes.string
 }
 
 App.defaultProps = {

--- a/src/components/CustomizationAccordion.js
+++ b/src/components/CustomizationAccordion.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   Container,
   Collapse,
@@ -193,5 +194,10 @@ class VisualizationOptions extends Component {
     );
   }
 }
+
+VisualizationOptions.propTypes = {
+  handleMappingQualityCutoffChange: PropTypes.func.isRequired,
+  setColorSetting: PropTypes.func.isRequired
+};
 
 export default VisualizationOptions;

--- a/src/components/DataPositionFormRow.js
+++ b/src/components/DataPositionFormRow.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Form, Label, Input, Button } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -120,5 +121,16 @@ class DataPositionFormRow extends Component {
     );
   }
 }
+
+DataPositionFormRow.propTypes = {
+  byNode: PropTypes.oneOf(['true', 'false']).isRequired,
+  distance: PropTypes.string.isRequired, 
+  handleGoButton: PropTypes.func.isRequired,
+  handleGoLeft: PropTypes.func.isRequired,
+  handleGoRight: PropTypes.func.isRequired,
+  handleInputChange: PropTypes.func.isRequired,
+  nodeID: PropTypes.string.isRequired,
+  uploadInProgress: PropTypes.bool.isRequired,
+};
 
 export default DataPositionFormRow;

--- a/src/components/ExampleSelectButtons.js
+++ b/src/components/ExampleSelectButtons.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Form, Button } from 'reactstrap';
 import { dataOriginTypes } from '../enums';
 
@@ -72,5 +73,10 @@ class ExampleSelectButtons extends Component {
     );
   }
 }
+
+ExampleSelectButtons.propTypes = {
+  setColorSetting: PropTypes.func.isRequired,
+  setDataOrigin: PropTypes.func.isRequired
+};
 
 export default ExampleSelectButtons;

--- a/src/components/FileUploadFormRow.js
+++ b/src/components/FileUploadFormRow.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Label, Input } from 'reactstrap';
 
 const MAX_UPLOAD_SIZE = 5242880;
@@ -163,5 +164,17 @@ class FileUploadFormRow extends Component {
     );
   }
 }
+
+FileUploadFormRow.propTypes = {
+  backendUrl: PropTypes.string.isRequired,
+  getPathNames: PropTypes.func.isRequired,
+  handleFileUpload: PropTypes.func.isRequired,
+  handleInputChange: PropTypes.func.isRequired,
+  pathSelect: PropTypes.string.isRequired, 
+  pathSelectOptions: PropTypes.array.isRequired, 
+  resetPathNames: PropTypes.func.isRequired,
+  setUploadInProgress: PropTypes.func.isRequired,
+  showFileSizeAlert: PropTypes.func.isRequired
+};
 
 export default FileUploadFormRow;

--- a/src/components/HeaderForm.js
+++ b/src/components/HeaderForm.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Container, Row, Col, Form, Label, Input, Alert } from 'reactstrap';
 import { dataOriginTypes } from '../enums';
 // import defaultConfig from '../config.default.json';
@@ -305,6 +306,7 @@ class HeaderForm extends Component {
                 )}
                 {uploadFilesFlag && (
                   <FileUploadFormRow
+                    backendUrl={this.props.backendUrl}
                     pathSelect={this.state.pathSelect}
                     pathSelectOptions={this.state.pathSelectOptions}
                     handleInputChange={this.handleInputChange}
@@ -352,5 +354,13 @@ class HeaderForm extends Component {
     );
   }
 }
+
+HeaderForm.propTypes = {
+  backendUrl: PropTypes.string.isRequired,
+  dataOrigin: PropTypes.string.isRequired,
+  setColorSetting: PropTypes.func.isRequired,
+  setDataOrigin: PropTypes.func.isRequired,
+  setFetchParams: PropTypes.func.isRequired
+};
 
 export default HeaderForm;

--- a/src/components/MountedDataFormRow.js
+++ b/src/components/MountedDataFormRow.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Label, Input } from 'reactstrap';
 
 class MountedDataFormRow extends Component {
@@ -103,5 +104,17 @@ class MountedDataFormRow extends Component {
     );
   }
 }
+
+MountedDataFormRow.propTypes = {
+  gamSelect: PropTypes.string.isRequired,
+  gamSelectOptions: PropTypes.array.isRequired,
+  gbwtSelect: PropTypes.string.isRequired,
+  gbwtSelectOptions: PropTypes.array.isRequired,
+  handleInputChange: PropTypes.func.isRequired,
+  pathSelect: PropTypes.string.isRequired,
+  pathSelectOptions: PropTypes.array.isRequired,
+  xgSelect: PropTypes.string.isRequired,
+  xgSelectOptions: PropTypes.array.isRequired
+};
 
 export default MountedDataFormRow;

--- a/src/components/RadioRow.js
+++ b/src/components/RadioRow.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Col, Label, Input, FormGroup } from 'reactstrap';
 
 const colorMap = new Map([
@@ -43,5 +44,12 @@ class RadioRow extends Component {
     );
   }
 }
+
+RadioRow.propTypes = {
+  color: PropTypes.string.isRequired,
+  rowHeading: PropTypes.string.isRequired,
+  setColorSetting: PropTypes.func.isRequired,
+  trackType: PropTypes.string.isRequired 
+};
 
 export default RadioRow;

--- a/src/components/TubeMap.js
+++ b/src/components/TubeMap.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import * as tubeMap from '../util/tubemap';
 
 class TubeMap extends Component {
@@ -23,5 +24,11 @@ class TubeMap extends Component {
     return <svg id="svg" />;
   }
 }
+
+TubeMap.propTypes = {
+  nodes: PropTypes.array.isRequired,
+  tracks: PropTypes.array.isRequired,
+  reads: PropTypes.array.isRequired 
+};
 
 export default TubeMap;

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import TubeMap from './TubeMap';
 import { Container, Row, Alert } from 'reactstrap';
 import * as tubeMap from '../util/tubemap';
@@ -160,5 +161,11 @@ class TubeMapContainer extends Component {
     return result;
   };
 }
+
+TubeMapContainer.propTypes = {
+  backendUrl: PropTypes.string.isRequired,
+  dataOrigin: PropTypes.oneOf(Object.values(dataOriginTypes)).isRequired,
+  fetchParams: PropTypes.object.isRequired 
+};
 
 export default TubeMapContainer;

--- a/src/server.js
+++ b/src/server.js
@@ -108,9 +108,10 @@ function indexGamSorted(req, res) {
 app.post('/getChunkedData', (req, res) => {
   let sentErrorResponse = false;
   console.time('request-duration');
-  console.log('http POST chr22_v4 received');
-  console.log(`nodeID = ${req.body.nodeID}`);
+  console.log('http POST getChunkedData received');
+  console.log(`start = ${req.body.nodeID}`);
   console.log(`distance = ${req.body.distance}`);
+  console.log(`byNode = ${req.body.byNode}`);
 
   // Assign each request a UUID. v1 UUIDs can be very similar for similar
   // timestamps on the same node, but are still guaranteed to be unique within
@@ -190,6 +191,8 @@ app.post('/getChunkedData', (req, res) => {
     '-E',
     `${req.tempDir}/regions.tsv`
   );
+
+  console.log(`vg chunk ${vgChunkParams.join(' ')}`);
 
   console.time('vg chunk');
   const vgChunkCall = spawn(`${VG_PATH}vg`, vgChunkParams);
@@ -352,6 +355,7 @@ function processRegionFile(req, res) {
   });
 
   lineReader.on('line', line => {
+    console.log('Region: ' + line);
     const arr = line.replace(/\s+/g, ' ').split(' ');
     req.graph.path.forEach(path => {
       if (path.name === arr[0]) path.indexOfFirstBase = arr[1];


### PR DESCRIPTION
This fixes #114.

The underlying problem was that a prop that was supposed to be filled in wasn't, so I pulled in `prop-types` so we should now get browser console complaints if a prop isn't set when it should be.