### PR TITLE
Move API to `/api/v0` and proxy web sockets

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -8,7 +8,7 @@ Here are the steps to deploy an update to the demo at [https://vgteam.github.io/
 "homepage": "https://vgteam.github.io/sequenceTubeMap/"
 ```
 
-- Modify the `BACKEND_URL` in `src/config.json`:
+- Modify the `BACKEND_URL` in `src/config.json`. Note that it should not include `/api` or anything after it:
 
 ```
 "BACKEND_URL": "https://api.tubemap.graphs.vg",

--- a/src/App.js
+++ b/src/App.js
@@ -131,7 +131,7 @@ App.defaultProps = {
   // the config or the browser, but needs to be swapped out in the fake
   // browser testing environment to point to a real testing backend.
   // Note that host includes the port.
-  backendUrl: config.BACKEND_URL || `http://${window.location.host}/api/v0`
+  backendUrl: (config.BACKEND_URL || `http://${window.location.host}`) + '/api/v0'
 };
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -131,7 +131,7 @@ App.defaultProps = {
   // the config or the browser, but needs to be swapped out in the fake
   // browser testing environment to point to a real testing backend.
   // Note that host includes the port.
-  backendUrl: config.BACKEND_URL || `http://${window.location.host}`
+  backendUrl: config.BACKEND_URL || `http://${window.location.host}/api/v0`
 };
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -102,12 +102,12 @@ class App extends Component {
           setDataOrigin={this.setDataOrigin}
           setColorSetting={this.setColorSetting}
           dataOrigin={this.state.dataOrigin}
-          backendUrl={this.props.backendUrl}
+          apiUrl={this.props.apiUrl}
         />
         <TubeMapContainer
           fetchParams={this.state.fetchParams}
           dataOrigin={this.state.dataOrigin}
-          backendUrl={this.props.backendUrl}
+          apiUrl={this.props.apiUrl}
         />
         <CustomizationAccordion
           visOptions={this.state.visOptions}
@@ -123,7 +123,7 @@ class App extends Component {
 }
 
 App.propTypes = {
-  backendUrl: PropTypes.string
+  apiUrl: PropTypes.string
 }
 
 App.defaultProps = {
@@ -131,7 +131,7 @@ App.defaultProps = {
   // the config or the browser, but needs to be swapped out in the fake
   // browser testing environment to point to a real testing backend.
   // Note that host includes the port.
-  backendUrl: (config.BACKEND_URL || `http://${window.location.host}`) + '/api/v0'
+  apiUrl: (config.BACKEND_URL || `http://${window.location.host}`) + '/api/v0'
 };
 
 export default App;

--- a/src/components/FileUploadFormRow.js
+++ b/src/components/FileUploadFormRow.js
@@ -36,7 +36,7 @@ class FileUploadFormRow extends Component {
           this.props.getPathNames(xhr.response.path, 'true');
         }
       };
-      xhr.open('POST', `${this.props.backendUrl}/xgFileSubmission`, true);
+      xhr.open('POST', `${this.props.apiUrl}/xgFileSubmission`, true);
       xhr.send(formData);
     }
   };
@@ -63,7 +63,7 @@ class FileUploadFormRow extends Component {
           this.props.handleFileUpload('gbwtFile', xhr.response.path);
         }
       };
-      xhr.open('POST', `${this.props.backendUrl}/gbwtFileSubmission`, true);
+      xhr.open('POST', `${this.props.apiUrl}/gbwtFileSubmission`, true);
       xhr.send(formData);
     }
   };
@@ -90,7 +90,7 @@ class FileUploadFormRow extends Component {
           this.props.handleFileUpload('gamFile', xhr.response.path);
         }
       };
-      xhr.open('POST', `${this.props.backendUrl}/gamFileSubmission`, true);
+      xhr.open('POST', `${this.props.apiUrl}/gamFileSubmission`, true);
       xhr.send(formData);
     }
   };
@@ -166,7 +166,7 @@ class FileUploadFormRow extends Component {
 }
 
 FileUploadFormRow.propTypes = {
-  backendUrl: PropTypes.string.isRequired,
+  apiUrl: PropTypes.string.isRequired,
   getPathNames: PropTypes.func.isRequired,
   handleFileUpload: PropTypes.func.isRequired,
   handleInputChange: PropTypes.func.isRequired,

--- a/src/components/HeaderForm.js
+++ b/src/components/HeaderForm.js
@@ -54,7 +54,7 @@ class HeaderForm extends Component {
 
   getMountedFilenames = async () => {
     try {
-      const response = await fetch(`${this.props.backendUrl}/getFilenames`, {
+      const response = await fetch(`${this.props.apiUrl}/getFilenames`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json'
@@ -85,13 +85,13 @@ class HeaderForm extends Component {
         };
       });
     } catch (error) {
-      console.log(`GET to ${this.props.backendUrl}/getFilenames failed:`, error);
+      console.log(`GET to ${this.props.apiUrl}/getFilenames failed:`, error);
     }
   };
 
   getPathNames = async (xgFile, isUploadedFile) => {
     try {
-      const response = await fetch(`${this.props.backendUrl}/getPathNames`, {
+      const response = await fetch(`${this.props.apiUrl}/getPathNames`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -110,7 +110,7 @@ class HeaderForm extends Component {
         };
       });
     } catch (error) {
-      console.log(`POST to ${this.props.backendUrl}/getPathNames failed:`, error);
+      console.log(`POST to ${this.props.apiUrl}/getPathNames failed:`, error);
     }
   };
 
@@ -232,7 +232,7 @@ class HeaderForm extends Component {
   };
 
   setUpWebsocket = () => {
-    this.ws = new WebSocket(this.props.backendUrl.replace(/^http/, 'ws'));
+    this.ws = new WebSocket(this.props.apiUrl.replace(/^http/, 'ws'));
     this.ws.onmessage = message => {
       this.getMountedFilenames();
     };
@@ -306,7 +306,7 @@ class HeaderForm extends Component {
                 )}
                 {uploadFilesFlag && (
                   <FileUploadFormRow
-                    backendUrl={this.props.backendUrl}
+                    apiUrl={this.props.apiUrl}
                     pathSelect={this.state.pathSelect}
                     pathSelectOptions={this.state.pathSelectOptions}
                     handleInputChange={this.handleInputChange}
@@ -356,7 +356,7 @@ class HeaderForm extends Component {
 }
 
 HeaderForm.propTypes = {
-  backendUrl: PropTypes.string.isRequired,
+  apiUrl: PropTypes.string.isRequired,
   dataOrigin: PropTypes.string.isRequired,
   setColorSetting: PropTypes.func.isRequired,
   setDataOrigin: PropTypes.func.isRequired,

--- a/src/components/HeaderForm.js
+++ b/src/components/HeaderForm.js
@@ -55,7 +55,7 @@ class HeaderForm extends Component {
   getMountedFilenames = async () => {
     try {
       const response = await fetch(`${this.props.backendUrl}/getFilenames`, {
-        method: 'POST',
+        method: 'GET',
         headers: {
           'Content-Type': 'application/json'
         }
@@ -85,7 +85,7 @@ class HeaderForm extends Component {
         };
       });
     } catch (error) {
-      console.log(`POST to ${this.props.backendUrl}/getFilenames failed:`, error);
+      console.log(`GET to ${this.props.backendUrl}/getFilenames failed:`, error);
     }
   };
 

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -84,7 +84,7 @@ class TubeMapContainer extends Component {
   getRemoteTubeMapData = async () => {
     this.setState({ isLoading: true, error: null });
     try {
-      const response = await fetch(`${this.props.backendUrl}/getChunkedData`, {
+      const response = await fetch(`${this.props.apiUrl}/getChunkedData`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -163,7 +163,7 @@ class TubeMapContainer extends Component {
 }
 
 TubeMapContainer.propTypes = {
-  backendUrl: PropTypes.string.isRequired,
+  apiUrl: PropTypes.string.isRequired,
   dataOrigin: PropTypes.oneOf(Object.values(dataOriginTypes)).isRequired,
   fetchParams: PropTypes.object.isRequired 
 };

--- a/src/end-to-end.test.js
+++ b/src/end-to-end.test.js
@@ -19,7 +19,7 @@ async function setUp() {
   serverState = await server.start();
   
   // Create the application.
-  render(<App backendUrl={serverState.getUrl()} />)
+  render(<App apiUrl={serverState.getApiUrl()} />)
 }
 
 // This needs to be called by global and per-scope afterEach

--- a/src/server.js
+++ b/src/server.js
@@ -496,6 +496,10 @@ function start() {
       // Get the URL the server is listening on
       getUrl: () => {
         return 'http://localhost:' + SERVER_PORT;
+      },
+      // Get the URL the server is listening on for the API
+      getApiUrl: () => {
+        return state.getUrl() + '/api/v0';
       }
     };
 

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,8 @@
+// Configure the React development server to proxy both normal API calls and web socket requests.
+const proxy = require('http-proxy-middleware');
+
+module.exports = function(app) {
+  // When we set up the proxy this way we don't have to do anything special for the websockets.
+  app.use(proxy('http://localhost:3000/api'));
+};
+


### PR DESCRIPTION
To get the React dev server to proxy the web sockets through properly, I've had to put the API on its own path separate from the static files. But with that and a manual proxy configuration, the websockets are back to working.