### PR TITLE
Add search to dropdowns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules
 .DS_store
 .publish
 .vscode
+.idea
 build/
 *.swp

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "4.0.3",
+    "react-select": "^4.3.1",
     "reactstrap": "^8.0.0",
     "uuid": "^3.0.1",
     "webpack": "4.44.2",

--- a/src/App.css
+++ b/src/App.css
@@ -29,6 +29,17 @@ input[type='file'] {
   width: 200px;
 }
 
+.dropdown {
+  width: 100%;
+  margin-right: 0 !important;
+}
+
+@media (min-width: 576px) {
+  .dropdown {
+    width: auto;
+  }
+}
+
 /* the div containing the tubemap svg */
 #tubeMapSVG {
   overflow: auto;

--- a/src/components/FileUploadFormRow.js
+++ b/src/components/FileUploadFormRow.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Label, Input } from 'reactstrap';
+import SelectionDropdown from "./SelectionDropdown";
 
 const MAX_UPLOAD_SIZE = 5242880;
 
@@ -96,14 +97,6 @@ class FileUploadFormRow extends Component {
   };
 
   render() {
-    const pathDropdownOptions = this.props.pathSelectOptions.map(pathName => {
-      return (
-        <option value={pathName} key={pathName}>
-          {pathName}
-        </option>
-      );
-    });
-
     return (
       <React.Fragment>
         <Label className="customData tight-label mb-2 mr-sm-2 mb-sm-0 ml-2">
@@ -151,15 +144,14 @@ class FileUploadFormRow extends Component {
         >
           Path name:
         </Label>
-        <Input
-          type="select"
-          className="customData custom-select mb-2 mr-sm-4 mb-sm-0"
+        <SelectionDropdown
+          className="customData dropdown mb-2 mr-sm-4 mb-sm-0"
           id="pathSelect"
           value={this.props.pathSelect}
           onChange={this.props.handleInputChange}
-        >
-          {pathDropdownOptions}
-        </Input>
+          options={this.props.pathSelectOptions}
+        />
+
       </React.Fragment>
     );
   }
@@ -170,8 +162,8 @@ FileUploadFormRow.propTypes = {
   getPathNames: PropTypes.func.isRequired,
   handleFileUpload: PropTypes.func.isRequired,
   handleInputChange: PropTypes.func.isRequired,
-  pathSelect: PropTypes.string.isRequired, 
-  pathSelectOptions: PropTypes.array.isRequired, 
+  pathSelect: PropTypes.string.isRequired,
+  pathSelectOptions: PropTypes.array.isRequired,
   resetPathNames: PropTypes.func.isRequired,
   setUploadInProgress: PropTypes.func.isRequired,
   showFileSizeAlert: PropTypes.func.isRequired

--- a/src/components/MountedDataFormRow.js
+++ b/src/components/MountedDataFormRow.js
@@ -1,57 +1,22 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Label, Input } from 'reactstrap';
+import { Label } from 'reactstrap';
+import SelectionDropdown from "./SelectionDropdown";
 
 class MountedDataFormRow extends Component {
   render() {
-    const xgFileDropdownOptions = this.props.xgSelectOptions.map(fileName => {
-      return (
-        <option value={fileName} key={fileName}>
-          {fileName}
-        </option>
-      );
-    });
-
-    const gbwtFileDropdownOptions = this.props.gbwtSelectOptions.map(
-      fileName => {
-        return (
-          <option value={fileName} key={fileName}>
-            {fileName}
-          </option>
-        );
-      }
-    );
-
-    const gamFileDropdownOptions = this.props.gamSelectOptions.map(fileName => {
-      return (
-        <option value={fileName} key={fileName}>
-          {fileName}
-        </option>
-      );
-    });
-
-    const pathDropdownOptions = this.props.pathSelectOptions.map(pathName => {
-      return (
-        <option value={pathName} key={pathName}>
-          {pathName}
-        </option>
-      );
-    });
-
     return (
       <React.Fragment>
         <Label className="customData tight-label mb-2 mr-sm-2 mb-sm-0 ml-2">
           xg file:
         </Label>
-        <Input
-          type="select"
-          className="customDataMounted custom-select mb-2 mr-sm-4 mb-sm-0"
+        <SelectionDropdown
+          className="customDataMounted dropdown mb-2 mr-sm-4 mb-sm-0"
           id="xgSelect"
           value={this.props.xgSelect}
           onChange={this.props.handleInputChange}
-        >
-          {xgFileDropdownOptions}
-        </Input>
+          options={this.props.xgSelectOptions}
+        />
 
         <Label
           for="gbwtFileSelect"
@@ -59,15 +24,13 @@ class MountedDataFormRow extends Component {
         >
           gbwt file:
         </Label>
-        <Input
-          type="select"
-          className="customDataMounted custom-select mb-2 mr-sm-4 mb-sm-0"
+        <SelectionDropdown
+          className="customDataMounted dropdown mb-2 mr-sm-4 mb-sm-0"
           id="gbwtSelect"
           value={this.props.gbwtSelect}
           onChange={this.props.handleInputChange}
-        >
-          {gbwtFileDropdownOptions}
-        </Input>
+          options={this.props.gbwtSelectOptions}
+        />
 
         <Label
           for="gamFileSelect"
@@ -75,15 +38,13 @@ class MountedDataFormRow extends Component {
         >
           gam index:
         </Label>
-        <Input
-          type="select"
-          className="customDataMounted custom-select mb-2 mr-sm-4 mb-sm-0"
+        <SelectionDropdown
+          className="customDataMounted dropdown mb-2 mr-sm-4 mb-sm-0"
           id="gamSelect"
           value={this.props.gamSelect}
           onChange={this.props.handleInputChange}
-        >
-          {gamFileDropdownOptions}
-        </Input>
+          options={this.props.gamSelectOptions}
+        />
 
         <Label
           for="pathName"
@@ -91,15 +52,13 @@ class MountedDataFormRow extends Component {
         >
           Path name:
         </Label>
-        <Input
-          type="select"
-          className="customData custom-select mb-2 mr-sm-4 mb-sm-0"
+        <SelectionDropdown
+          className="customData dropdown mb-2 mr-sm-4 mb-sm-0"
           id="pathSelect"
           value={this.props.pathSelect}
           onChange={this.props.handleInputChange}
-        >
-          {pathDropdownOptions}
-        </Input>
+          options={this.props.pathSelectOptions}
+        />
       </React.Fragment>
     );
   }

--- a/src/components/SelectionDropdown.js
+++ b/src/components/SelectionDropdown.js
@@ -1,0 +1,78 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import Select from "react-select";
+
+
+/**
+ * A searchable selection dropdown component.
+ */
+class SelectionDropdown extends Component {
+  render() {
+    // Tweaks to the default react-select styles so that it'll look good with tube maps.
+    const styles = {
+      control: base => ({
+        ...base,
+        minHeight: "unset",
+        height: "calc(2.25rem - 2px)"
+      }),
+      valueContainer: base => ({
+        ...base,
+        // Roughly calculate the width that can fit the largest text. This can't be updated dynamically.
+        width: Math.max(...this.props.options.map(option => option.length)) * 8 + 16,
+        minWidth: "48px",
+        position: "unset"
+      }),
+      indicatorsContainer: base => ({
+        ...base,
+        height: "inherit",
+      }),
+      menu: base => ({
+        ...base,
+        width: "max-content",
+        minWidth: "100%"
+      }),
+    }
+
+    const dropdownOptions = this.props.options.map(option => ({
+      label: option,
+      value: option,
+    }));
+
+    const onChange = (option) => {
+      this.props.onChange({
+        target: {
+          id: this.props.id,
+          value: option.value,
+        }
+      });
+    }
+
+    return (
+      <Select
+        id={this.props.id}
+        className={this.props.className}
+        value={dropdownOptions.find((option) => option.value === this.props.value) || {}}
+        styles={styles}
+        isSearchable={true}
+        onChange={onChange}
+        options={dropdownOptions}
+      />
+    )
+  }
+}
+
+SelectionDropdown.propTypes = {
+  id: PropTypes.string,
+  className: PropTypes.string,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.array.isRequired,
+};
+
+SelectionDropdown.defaultProps = {
+  id: undefined,
+  className: undefined,
+  value: undefined,
+};
+
+export default SelectionDropdown;

--- a/src/components/SelectionDropdown.js
+++ b/src/components/SelectionDropdown.js
@@ -56,6 +56,7 @@ class SelectionDropdown extends Component {
         isSearchable={true}
         onChange={onChange}
         options={dropdownOptions}
+        openMenuOnClick={dropdownOptions.length < 2000}
       />
     )
   }


### PR DESCRIPTION
Closes #115. This replaces a bunch of dropdowns with a custom searchable Select component from `react-select`. 

The UI will be slower with thousands of options since it's not using the native \<select\>\<option\> tags, but hopefully the search would help with that.