### PR TITLE
Bring back isCompletelyReverse for layout, and consult it when generating ticks

### DIFF
--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -114,7 +114,10 @@ class TubeMapContainer extends Component {
 
   getExampleData = async () => {
     this.setState({ isLoading: true, error: null });
-    let nodes, tracks, reads;
+    // Nodes, tracks, and reads are all required, so start with defaults.
+    let nodes = [];
+    let tracks = [];
+    let reads = [];
     const data = await import('../util/demo-data');
     nodes = data.inputNodes;
     switch (this.props.dataOrigin) {


### PR DESCRIPTION
This will fix #133 by going back to the old method of flipping paths that visit all nodes in reverse, for layout purposes. The tick generator can now tell when the ruler track has been flipped like this, and unflip it for tick generation.

I still think we need to rethink a lot of the orientation support to be able to know if it is really correct. But this will make the Cactus graph example look nice without reintroducing #88.