### PR TITLE
Reverse complement sequence when switching nodes

### DIFF
--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -1589,10 +1589,7 @@ function switchNodeOrientation() {
   toSwitch.forEach((value, key) => {
     if (value > 0) {
       currentNode = nodeMap.get(key);
-      nodes[currentNode].seq = nodes[currentNode].seq
-        .split("")
-        .reverse()
-        .join("");
+      nodes[currentNode].seq = getReverseComplement(nodes[currentNode].seq);
       nodes[currentNode].switched = true;
     }
   });


### PR DESCRIPTION
When most paths go through a node in reverse, tubemap will switch it to make the graph visually better. However, the sequence  of the switched node was incorrect (reverse instead of reverse-complement). This fixes that, now the reverse-complemented sequence is shown on "switched" nodes.