### PR TITLE
Fix an error when no regions are selected for mount data

### DIFF
--- a/src/components/HeaderForm.js
+++ b/src/components/HeaderForm.js
@@ -257,7 +257,9 @@ class HeaderForm extends Component {
           xgFile: state.xgSelect,
           gbwtFile: state.gbwtSelect,
           gamFile: state.gamSelect,
-          bedFile: state.bedSelect,
+          bedFile: "none",
+          // not sure why we would like to keep the previous selection when changing data sources. What I know is it creates a bug for the regions, where the tubemap tries to read the previous bedFile (e.g. defaulted to example 1), can't find it and raises an error
+          // bedFile: state.bedSelect,
           dataPath: "mounted",
           dataType: dataTypes.MOUNTED_FILES,
         };
@@ -360,7 +362,9 @@ class HeaderForm extends Component {
     } else if (id === "gamSelect") {
       this.setState({ gamFile: value });
     } else if (id === "bedSelect") {
-      this.getBedRegions(value, this.state.dataPath);
+      if (value !== "none") {
+        this.getBedRegions(value, this.state.dataPath);
+      }
       this.setState({ bedFile: value });
     }
   };


### PR DESCRIPTION
It looks like the default selection for the "region" file is not initialized properly after startup when switching to mounted data. It looks for the BED file from the example, can't find it in the mounted data folder, and raises an error. 

I've made it so that the value of the default BED file is re-initialized (to "none") when switching data sources. I don't think we want to keep the previous selection if we're changing data sources. 

I've also added a test to only read a BED file if there is a selected BED file (i.e. not *none*)