### PR TITLE
CopyLink: Use window.location.origin instead of window.location.host

### DIFF
--- a/src/components/CopyLink.js
+++ b/src/components/CopyLink.js
@@ -23,7 +23,7 @@ export function CopyLink(props) {
     const viewTarget = props.getCurrentViewTarget();
 
     const params = new URLSearchParams(viewTarget).toString();
-    const full = window.location.host + "?" + params;
+    const full = window.location.origin + "?" + params;
     copyCallback(full);
 
     // Write link to clipboard


### PR DESCRIPTION
CopyLink does not work if HTTPS is used for the the app. The protocol is missing.