### PR TITLE
Different Colors for Haplotype and GAM Files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "concurrently": "^7.5.0",
         "d3": "^5.9.2",
         "d3-selection-multi": "^1.0.1",
+        "deep-equal": "^2.2.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "fs-extra": "^10.1.0",
@@ -5045,6 +5046,17 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
@@ -6922,6 +6934,38 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
+      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-equal/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -7391,6 +7435,30 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
@@ -8530,6 +8598,14 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.2.tgz",
@@ -8793,9 +8869,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -8985,6 +9061,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -9548,11 +9635,11 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dependencies": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
@@ -9566,6 +9653,34 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-arrayish": {
@@ -9700,6 +9815,14 @@
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -9793,6 +9916,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -9843,10 +9974,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
@@ -9854,6 +10011,18 @@
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "dependencies": {
         "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11512,6 +11681,21 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -14844,6 +15028,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dependencies": {
+        "internal-slot": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
@@ -16208,6 +16403,39 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -20109,6 +20337,11 @@
         "postcss-value-parser": "^4.2.0"
       }
     },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+    },
     "axe-core": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
@@ -21557,6 +21790,37 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
     },
+    "deep-equal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
+      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
+      }
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -21917,6 +22181,29 @@
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
+      }
+    },
+    "es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
       }
     },
     "es-module-lexer": {
@@ -22769,6 +23056,14 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.2.tgz",
@@ -22947,9 +23242,9 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -23088,6 +23383,14 @@
         "object-assign": "^4.0.1",
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "graceful-fs": {
@@ -23499,11 +23802,11 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "requires": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
@@ -23512,6 +23815,25 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -23597,6 +23919,11 @@
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
+    "is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+    },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -23654,6 +23981,11 @@
       "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
       "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg=="
     },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
+    },
     "is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -23683,10 +24015,27 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -23694,6 +24043,15 @@
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "requires": {
         "call-bind": "^1.0.2"
+      }
+    },
+    "is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       }
     },
     "is-wsl": {
@@ -24964,6 +25322,15 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+    },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
     },
     "object-keys": {
       "version": "1.1.1",
@@ -27273,6 +27640,14 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "requires": {
+        "internal-slot": "^1.0.4"
+      }
+    },
     "streamsearch": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
@@ -28241,6 +28616,30 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "concurrently": "^7.5.0",
     "d3": "^5.9.2",
     "d3-selection-multi": "^1.0.1",
+    "deep-equal": "^2.2.0",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "fs-extra": "^10.1.0",

--- a/src/App.js
+++ b/src/App.js
@@ -37,10 +37,11 @@ class App extends Component {
         showReads: true,
         showSoftClips: true,
         colorReadsByMappingQuality: false,
-        colorSchemes: [{"mainPallate": "ygreys", "auxPallate": "ygreys", "colorReadsByMappingQuality": false},
-                 {"mainPallate": "ygreys", "auxPallate": "ygreys", "colorReadsByMappingQuality": false},
-                 {"mainPallate": "reds", "auxPallate": "blues", "colorReadsByMappingQuality": false},
-                 {"mainPallate": "reds", "auxPallate": "blues", "colorReadsByMappingQuality": false}],
+        colorSchemes: [
+                  {...config.defaultHaplotypeColorPallete},
+                  {...config.defaultHaplotypeColorPallete},
+                  {...config.defaultReadColorPallete},
+                  {...config.defaultReadColorPallete}],
         mappingQualityCutoff: 0,
       },
     };
@@ -122,14 +123,14 @@ class App extends Component {
 
   // Set a color scheme setting for a particular track.
   //
-  // key is the name of the setting to set, and may be "mainPallate", "auxPallate", or "colorByMappingQuality".
+  // key is the name of the setting to set, and may be "mainPallete", "auxPallete", or "colorByMappingQuality".
   //
   // index is the index in the tracks array of the track to operate on. For now,
   // haplotypes and paths are lumped together as track 0 here, with up to two
   // tracks of reads afterward; eventually this will follow the indexing of the real
   // tracks array. 
   //
-  // value is the value to set. For "mainPallate" and "auxPallate" this is the name
+  // value is the value to set. For "mainPallete" and "auxPallete" this is the name
   // of a color palette, such as "reds".
   setColorSetting = (key, index, value) => {
     let newcolors = [...this.state.visOptions.colorSchemes]

--- a/src/App.js
+++ b/src/App.js
@@ -66,13 +66,8 @@ class App extends Component {
       // update tubemap colors 
       tubeMap.setColorSet(i, visOptions.colors[i]);
     }
-
-
-    
-
     tubeMap.setMappingQualityCutoff(visOptions.mappingQualityCutoff);
 
-    console.log(visOptions.colors);
   }
   /*
    * Drop undefined values

--- a/src/App.js
+++ b/src/App.js
@@ -58,10 +58,15 @@ class App extends Component {
     tubeMap.setShowReadsFlag(visOptions.showReads);
     tubeMap.setSoftClipsFlag(visOptions.showSoftClips);
 
-    //To be changed, add options to change colorReadsByMappingQuality individually
+    // apply new colorReadsByMappingQuality value to all tracks
+    // to be changed, add options to change colorReadsByMappingQuality individually
+    tubeMap.setColorReadsByMappingQualityFlag(visOptions.colorReadsByMappingQuality);
+
     for (let i = 0; i < visOptions.colors.length; i++) {
-      visOptions.colors[i].colorReadsByMappingQuality = visOptions.colorReadsByMappingQuality;
+      // update tubemap colors 
+      tubeMap.setColorSet(i, visOptions.colors[i]);
     }
+
 
     
 

--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,9 @@ class App extends Component {
         forwardReadColors: "reds",
         reverseReadColors: "blues",
         colorReadsByMappingQuality: false,
+        colors: [{"forward": "ygreys", "reverse": "ygreys", "colorReadsByMappingQuality": false},
+                 {"forward": "reds", "reverse": "blues", "colorReadsByMappingQuality": false},
+                 {"forward": "reds", "reverse": "blues", "colorReadsByMappingQuality": false}],
         mappingQualityCutoff: 0,
       },
     };
@@ -54,13 +57,17 @@ class App extends Component {
     tubeMap.setTransparentNodesFlag(visOptions.transparentNodes);
     tubeMap.setShowReadsFlag(visOptions.showReads);
     tubeMap.setSoftClipsFlag(visOptions.showSoftClips);
-    tubeMap.setColorSet("haplotypeColors", visOptions.haplotypeColors);
-    tubeMap.setColorSet("forwardReadColors", visOptions.forwardReadColors);
-    tubeMap.setColorSet("reverseReadColors", visOptions.reverseReadColors);
-    tubeMap.setColorReadsByMappingQualityFlag(
-      visOptions.colorReadsByMappingQuality
-    );
+
+    //To be changed, add options to change colorReadsByMappingQuality individually
+    for (let i = 0; i < visOptions.colors.length; i++) {
+      visOptions.colors[i].colorReadsByMappingQuality = visOptions.colorReadsByMappingQuality;
+    }
+
+    
+
     tubeMap.setMappingQualityCutoff(visOptions.mappingQualityCutoff);
+
+    console.log(visOptions.colors);
   }
   /*
    * Drop undefined values
@@ -115,11 +122,14 @@ class App extends Component {
     }));
   };
 
-  setColorSetting = (key, value) => {
+  // key = forward/backward, index = index of colors (0 = haplotype)
+  setColorSetting = (key, index, value) => {
+    let newcolors = [...this.state.visOptions.colors]
+    newcolors[index][key] = value;
     this.setState((state) => ({
       visOptions: {
         ...state.visOptions,
-        [key]: value,
+        colors: newcolors,
       },
     }));
   };

--- a/src/App.js
+++ b/src/App.js
@@ -36,13 +36,11 @@ class App extends Component {
         transparentNodes: false,
         showReads: true,
         showSoftClips: true,
-        haplotypeColors: "ygreys",
-        forwardReadColors: "reds",
-        reverseReadColors: "blues",
         colorReadsByMappingQuality: false,
-        colors: [{"forward": "ygreys", "reverse": "ygreys", "colorReadsByMappingQuality": false},
-                 {"forward": "reds", "reverse": "blues", "colorReadsByMappingQuality": false},
-                 {"forward": "reds", "reverse": "blues", "colorReadsByMappingQuality": false}],
+        colorSchemes: [{"mainPallate": "ygreys", "auxPallate": "ygreys", "colorReadsByMappingQuality": false},
+                 {"mainPallate": "ygreys", "auxPallate": "ygreys", "colorReadsByMappingQuality": false},
+                 {"mainPallate": "reds", "auxPallate": "blues", "colorReadsByMappingQuality": false},
+                 {"mainPallate": "reds", "auxPallate": "blues", "colorReadsByMappingQuality": false}],
         mappingQualityCutoff: 0,
       },
     };
@@ -62,9 +60,9 @@ class App extends Component {
     // to be changed, add options to change colorReadsByMappingQuality individually
     tubeMap.setColorReadsByMappingQualityFlag(visOptions.colorReadsByMappingQuality);
 
-    for (let i = 0; i < visOptions.colors.length; i++) {
+    for (let i = 0; i < visOptions.colorSchemes.length; i++) {
       // update tubemap colors 
-      tubeMap.setColorSet(i, visOptions.colors[i]);
+      tubeMap.setColorSet(i, visOptions.colorSchemes[i]);
     }
     tubeMap.setMappingQualityCutoff(visOptions.mappingQualityCutoff);
 
@@ -122,9 +120,19 @@ class App extends Component {
     }));
   };
 
-  // key = forward/backward, index = index of colors (0 = haplotype)
+  // Set a color scheme setting for a particular track.
+  //
+  // key is the name of the setting to set, and may be "mainPallate", "auxPallate", or "colorByMappingQuality".
+  //
+  // index is the index in the tracks array of the track to operate on. For now,
+  // haplotypes and paths are lumped together as track 0 here, with up to two
+  // tracks of reads afterward; eventually this will follow the indexing of the real
+  // tracks array. 
+  //
+  // value is the value to set. For "mainPallate" and "auxPallate" this is the name
+  // of a color palette, such as "reds".
   setColorSetting = (key, index, value) => {
-    let newcolors = [...this.state.visOptions.colors]
+    let newcolors = [...this.state.visOptions.colorSchemes]
     newcolors[index][key] = value;
     this.setState((state) => ({
       visOptions: {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -52,3 +52,18 @@ type RegionInfo = {
   // Numerical string
   start: string[]
 }
+
+// Available color sets
+enum examplecolors{
+  greys,
+  ygreys,
+  blues,
+  reds,
+  plainColors,
+  lightColors
+}
+
+// tubemap.js
+// Stores the assigned color of the track system, also stores boolean colorReadsByMappingQuality
+// Each entry contains the coloring of 1 haplotype file or 1 read file
+type colors = [{"forward": examplecolors, "reverse": examplecolors, "colorReadsByMappingQuality": boolean}]

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -54,7 +54,7 @@ type RegionInfo = {
 }
 
 // Available color sets
-enum examplecolors{
+enum ColorPallete{
   greys,
   ygreys,
   blues,
@@ -63,7 +63,13 @@ enum examplecolors{
   lightColors
 }
 
-// tubemap.js
-// Stores the assigned color of the track system, also stores boolean colorReadsByMappingQuality
-// Each entry contains the coloring of 1 haplotype file or 1 read file
-type colors = [{"forward": examplecolors, "reverse": examplecolors, "colorReadsByMappingQuality": boolean}]
+// Describes the coloring information for a track
+type ColorScheme = {
+    mainPallate: ColorPallete,
+    auxPallate: ColorPallete,
+    colorReadsByMappingQuality: boolean
+}
+
+// Stores the assigned colorschemes of all tracks
+// Entries correspond to their track counterpart, e.g colorSchemes[0] corresponds to tracks[0]
+type colorSchemes = Array<ColorScheme>;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -65,8 +65,8 @@ enum ColorPallete{
 
 // Describes the coloring information for a track
 type ColorScheme = {
-    mainPallate: ColorPallete,
-    auxPallate: ColorPallete,
+    mainPallete: ColorPallete,
+    auxPallete: ColorPallete,
     colorReadsByMappingQuality: boolean
 }
 

--- a/src/components/CustomizationAccordion.js
+++ b/src/components/CustomizationAccordion.js
@@ -164,46 +164,46 @@ class VisualizationOptions extends Component {
                 <Form>
                   <RadioRow
                     rowHeading="Haplotypes Forward"
-                    color={visOptions.colors[0].forward}
-                    trackType="forward"
-                    index="0"
+                    color={visOptions.colorSchemes[1].mainPallate}
+                    trackType="mainPallate"
+                    index="1"
                     setColorSetting={this.props.setColorSetting}
                   />
                   <RadioRow
                     rowHeading="Haplotypes Reverse"
-                    color={visOptions.colors[0].reverse}
-                    trackType="reverse"
-                    index="0"
+                    color={visOptions.colorSchemes[1].auxPallate}
+                    trackType="auxPallate"
+                    index="1"
                     setColorSetting={this.props.setColorSetting}
                   />
                   {visOptions.showReads && (
                       <React.Fragment>
                         <RadioRow
                           rowHeading="Gam1 Forward"
-                          color={visOptions.colors[1].forward}
-                          trackType="forward"
-                          index="1"
+                          color={visOptions.colorSchemes[2].mainPallate}
+                          trackType="mainPallate"
+                          index="2"
                           setColorSetting={this.props.setColorSetting}
                         />
                         <RadioRow
                           rowHeading="Gam1 Reverse"
-                          color={visOptions.colors[1].reverse}
-                          trackType="reverse"
-                          index="1"
+                          color={visOptions.colorSchemes[2].auxPallate}
+                          trackType="auxPallate"
+                          index="2"
                           setColorSetting={this.props.setColorSetting}
                         />
                         <RadioRow
                           rowHeading="Gam2 Forward"
-                          color={visOptions.colors[2].forward}
-                          trackType="forward"
-                          index="2"
+                          color={visOptions.colorSchemes[3].mainPallate}
+                          trackType="mainPallate"
+                          index="3"
                           setColorSetting={this.props.setColorSetting}
                         />
                         <RadioRow
                           rowHeading="Gam2 Reverse"
-                          color={visOptions.colors[2].reverse}
-                          trackType="reverse"
-                          index="2"
+                          color={visOptions.colorSchemes[3].auxPallate}
+                          trackType="auxPallate"
+                          index="3"
                           setColorSetting={this.props.setColorSetting}
                         />
                       </React.Fragment>

--- a/src/components/CustomizationAccordion.js
+++ b/src/components/CustomizationAccordion.js
@@ -164,15 +164,15 @@ class VisualizationOptions extends Component {
                 <Form>
                   <RadioRow
                     rowHeading="Haplotypes Forward"
-                    color={visOptions.colorSchemes[1].mainPallate}
-                    trackType="mainPallate"
+                    color={visOptions.colorSchemes[1].mainPallete}
+                    trackType="mainPallete"
                     index="1"
                     setColorSetting={this.props.setColorSetting}
                   />
                   <RadioRow
                     rowHeading="Haplotypes Reverse"
-                    color={visOptions.colorSchemes[1].auxPallate}
-                    trackType="auxPallate"
+                    color={visOptions.colorSchemes[1].auxPallete}
+                    trackType="auxPallete"
                     index="1"
                     setColorSetting={this.props.setColorSetting}
                   />
@@ -180,29 +180,29 @@ class VisualizationOptions extends Component {
                       <React.Fragment>
                         <RadioRow
                           rowHeading="Gam1 Forward"
-                          color={visOptions.colorSchemes[2].mainPallate}
-                          trackType="mainPallate"
+                          color={visOptions.colorSchemes[2].mainPallete}
+                          trackType="mainPallete"
                           index="2"
                           setColorSetting={this.props.setColorSetting}
                         />
                         <RadioRow
                           rowHeading="Gam1 Reverse"
-                          color={visOptions.colorSchemes[2].auxPallate}
-                          trackType="auxPallate"
+                          color={visOptions.colorSchemes[2].auxPallete}
+                          trackType="auxPallete"
                           index="2"
                           setColorSetting={this.props.setColorSetting}
                         />
                         <RadioRow
                           rowHeading="Gam2 Forward"
-                          color={visOptions.colorSchemes[3].mainPallate}
-                          trackType="mainPallate"
+                          color={visOptions.colorSchemes[3].mainPallete}
+                          trackType="mainPallete"
                           index="3"
                           setColorSetting={this.props.setColorSetting}
                         />
                         <RadioRow
                           rowHeading="Gam2 Reverse"
-                          color={visOptions.colorSchemes[3].auxPallate}
-                          trackType="auxPallate"
+                          color={visOptions.colorSchemes[3].auxPallete}
+                          trackType="auxPallete"
                           index="3"
                           setColorSetting={this.props.setColorSetting}
                         />

--- a/src/components/CustomizationAccordion.js
+++ b/src/components/CustomizationAccordion.js
@@ -163,24 +163,47 @@ class VisualizationOptions extends Component {
                 <h5>Colors</h5>
                 <Form>
                   <RadioRow
-                    rowHeading="Haplotypes"
-                    color={visOptions.haplotypeColors}
-                    trackType="haplotypeColors"
+                    rowHeading="Haplotypes Forward"
+                    color={visOptions.colors[0].forward}
+                    trackType="forward"
+                    index="0"
                     setColorSetting={this.props.setColorSetting}
                   />
-                  {visOptions.showReads &&
-                    !visOptions.colorReadsByMappingQuality && (
+                  <RadioRow
+                    rowHeading="Haplotypes Reverse"
+                    color={visOptions.colors[0].reverse}
+                    trackType="reverse"
+                    index="0"
+                    setColorSetting={this.props.setColorSetting}
+                  />
+                  {visOptions.showReads && (
                       <React.Fragment>
                         <RadioRow
-                          rowHeading="Reads (forward strand)"
-                          color={visOptions.forwardReadColors}
-                          trackType="forwardReadColors"
+                          rowHeading="Gam1 Forward"
+                          color={visOptions.colors[1].forward}
+                          trackType="forward"
+                          index="1"
                           setColorSetting={this.props.setColorSetting}
                         />
                         <RadioRow
-                          rowHeading="Reads (reverse strand)"
-                          color={visOptions.reverseReadColors}
-                          trackType="reverseReadColors"
+                          rowHeading="Gam1 Reverse"
+                          color={visOptions.colors[1].reverse}
+                          trackType="reverse"
+                          index="1"
+                          setColorSetting={this.props.setColorSetting}
+                        />
+                        <RadioRow
+                          rowHeading="Gam2 Forward"
+                          color={visOptions.colors[2].forward}
+                          trackType="forward"
+                          index="2"
+                          setColorSetting={this.props.setColorSetting}
+                        />
+                        <RadioRow
+                          rowHeading="Gam2 Reverse"
+                          color={visOptions.colors[2].reverse}
+                          trackType="reverse"
+                          index="2"
                           setColorSetting={this.props.setColorSetting}
                         />
                       </React.Fragment>

--- a/src/components/ExampleSelectButtons.js
+++ b/src/components/ExampleSelectButtons.js
@@ -6,9 +6,11 @@ import { dataOriginTypes } from "../enums";
 class ExampleSelectButtons extends Component {
   handleClick = (dataOrigin, haploColor, readColor) => {
     this.props.setDataOrigin(dataOrigin);
-    this.props.setColorSetting("haplotypeColors", haploColor);
+    //set haplotype color
+    this.props.setColorSetting("forward", 0, haploColor);
     if (readColor) {
-      this.props.setColorSetting("forwardReadColors", readColor);
+      //set read color
+      this.props.setColorSetting("forward", 1, readColor);
     }
   };
 

--- a/src/components/RadioRow.js
+++ b/src/components/RadioRow.js
@@ -15,6 +15,7 @@ class RadioRow extends Component {
   onChange = (event) => {
     this.props.setColorSetting(
       this.props.trackType,
+      this.props.index,
       colorMap.get(event.target.value)
     );
   };
@@ -51,6 +52,7 @@ RadioRow.propTypes = {
   rowHeading: PropTypes.string.isRequired,
   setColorSetting: PropTypes.func.isRequired,
   trackType: PropTypes.string.isRequired,
+  index: PropTypes.number
 };
 
 export default RadioRow;

--- a/src/components/RadioRow.js
+++ b/src/components/RadioRow.js
@@ -52,7 +52,7 @@ RadioRow.propTypes = {
   rowHeading: PropTypes.string.isRequired,
   setColorSetting: PropTypes.func.isRequired,
   trackType: PropTypes.string.isRequired,
-  index: PropTypes.number
+  index: PropTypes.number.isRequired,
 };
 
 export default RadioRow;

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -125,6 +125,13 @@ class TubeMapContainer extends Component {
           readsArr.push(tubeMap.vgExtractReads(nodes, tracks, gam, readsArr.length));
         }
 
+        // Go through every read and assign it a source file number
+        for (let i = 0; i < readsArr.length; i++) {
+          for (let j = 0; j < readsArr[i].length; j++) {
+            readsArr[i][j].sourceReadID = i;
+          }
+        }
+
         // concatenate all reads together
         const reads = readsArr.flat();
 

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -124,11 +124,25 @@ class TubeMapContainer extends Component {
           // Include readsArr length to prevent duplicate ids
           readsArr.push(tubeMap.vgExtractReads(nodes, tracks, gam, readsArr.length));
         }
+        
+        // go through viewTarget and create array of read file track numbers
+        let sourceTrackIDs = [];
+        for (let i = 0; i < this.props.viewTarget.tracks.length; i++) {
+          const track = this.props.viewTarget.tracks[i];
+          //add track index to array if the track contains a gam file
+          for (const file of track.files) {
+            if (file.type === "read") {
+              sourceTrackIDs.push(i);
+              break;
+            }
+          }
+        }
 
+        console.log(sourceTrackIDs);
         // Go through every read and assign it a source file number
         for (let i = 0; i < readsArr.length; i++) {
           for (let j = 0; j < readsArr[i].length; j++) {
-            readsArr[i][j].sourceReadID = i;
+            readsArr[i][j].sourceTrackID = sourceTrackIDs[i];
           }
         }
 

--- a/src/config.json
+++ b/src/config.json
@@ -44,5 +44,17 @@
   ],
   "vgPath": "",
   "dataPath": "./exampleData",
-  "internalDataPath": "./exampleData/internal/"
+  "internalDataPath": "./exampleData/internal/",
+
+  "defaultHaplotypeColorPallete" : {
+    "mainPallete": "ygreys", 
+    "auxPallete": "ygreys", 
+    "colorReadsByMappingQuality": false
+  },
+  
+  "defaultReadColorPallete" : {
+    "mainPallete": "reds", 
+    "auxPallete": "blues", 
+    "colorReadsByMappingQuality": false
+  }
 }

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -88,11 +88,6 @@ const lightColors = [
 // if they don't have the first font named here.
 const fonts = '"Courier New", "Courier", "Lucida Console", monospace';
 
-let haplotypeColors = [];
-let forwardReadColors = [];
-let reverseReadColors = [];
-let gam1Colors = [];
-let gam2Colors = [];
 let colors = [{"forward": [], "reverse": []}, 
               {"forward": [], "reverse": []}, 
               {"forward": [], "reverse": []}];
@@ -130,11 +125,6 @@ const config = {
   nodeWidthOption: 0,
   showReads: true,
   showSoftClips: true,
-  haplotypeColors: "ygreys",
-  forwardReadColors: "reds",
-  reverseReadColors: "blues",
-  gam1Colors: "reds",
-  gam2Colors: "blues",
   colors: [{"forward": "ygreys", "reverse": "ygreys", "colorReadsByMappingQuality": false}, 
            {"forward": "reds", "reverse": "blues", "colorReadsByMappingQuality": false}, 
            {"forward": "reds", "reverse": "blues", "colorReadsByMappingQuality": false}], 
@@ -2271,11 +2261,6 @@ export function useColorScheme(x) {
 }
 
 function assignColorSets() {
-  haplotypeColors = getColorSet(config.haplotypeColors);
-  forwardReadColors = getColorSet(config.forwardReadColors);
-  reverseReadColors = getColorSet(config.reverseReadColors);
-  gam1Colors = getColorSet(config.gam1Colors);
-  gam2Colors = getColorSet(config.gam2Colors);
   exonColors = getColorSet(config.exonColors);
   for (let i = 0; i < config.colors.length; i++) {
     colors[i].forward = getColorSet(config.colors[i].forward);

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -333,11 +333,11 @@ export function setShowReadsFlag(value) {
   }
 }
 
-export function setColorSet(fileID, forwardColorSet, reverseColorSet) {
-  const fileColors = colors[fileID];
-  if ((config[fileColors.forward] !== forwardColorSet) || config[fileColors.reverse] !== reverseColorSet) {
-    config[fileColors.forward] = forwardColorSet;
-    config[fileColors.reverse] = reverseColorSet;
+export function setColorSet(fileID, newColor) {
+  const currColor = config.colors[fileID];
+  // update if forward or backward color is different
+  if ((currColor.forward !== newColor.forward) || (currColor.reverse !== newColor.reverse)) {
+    config.colors[fileID] = newColor;
     const tr = createTubeMap();
     if (!config.hideLegendFlag && tracks) drawLegend(tr);
   }
@@ -357,8 +357,13 @@ export function setNodeWidthOption(value) {
 }
 
 export function setColorReadsByMappingQualityFlag(value) {
+  // to be changed, add options to change colorReadsByMappingQuality individually
   if (config.colorReadsByMappingQuality !== value) {
     config.colorReadsByMappingQuality = value;
+    // update all values
+    for (let i = 0; i < config.colors.length; i++) {
+      config.colors[i].colorReadsByMappingQuality = value;
+    }
     svg = d3.select(svgID);
     createTubeMap();
   }

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -10,6 +10,7 @@
 /* eslint no-return-assign: "off" */
 import * as d3 from "d3";
 import "d3-selection-multi";
+import externalConfig from "../config.json";
 
 const deepEqual = require("deep-equal");
 
@@ -84,17 +85,6 @@ const lightColors = [
   "#A8E7ED",
 ];
 
-const defaultHaplotypeColorPallete = {
-  "mainPallate": "ygreys", 
-  "auxPallate": "ygreys", 
-  "colorReadsByMappingQuality": false
-}
-
-const defaultReadColorPallete = {
-  "mainPallate": "reds", 
-  "auxPallate": "blues", 
-  "colorReadsByMappingQuality": false
-}
 
 // Font stack we will use in the SVG
 // We start with Courier New because it exists a lot more places than
@@ -2287,7 +2277,7 @@ function generateTrackColor(track, highlight) {
   if (track.hasOwnProperty("type") && track.type === "read") {
     const sourceID = track.sourceTrackID;
     if (!config.colorSchemes[sourceID]) {
-      config.colorSchemes[sourceID] = defaultReadColorPallete;
+      config.colorSchemes[sourceID] = externalConfig.defaultReadColorPallete;
     }
     if (config.colorSchemes[sourceID].colorReadsByMappingQuality) {
       trackColor = d3.interpolateRdYlGn(
@@ -2296,23 +2286,23 @@ function generateTrackColor(track, highlight) {
     } else {
       if (track.hasOwnProperty("is_reverse") && track.is_reverse === true) {
         // get the color currently stored for this read source file, and stagger color using modulo
-        const colorSet = getColorSet(config.colorSchemes[sourceID].auxPallate);
+        const colorSet = getColorSet(config.colorSchemes[sourceID].auxPallete);
         trackColor = colorSet[track.id % colorSet.length];
       } else {
-        const colorSet = getColorSet(config.colorSchemes[sourceID].mainPallate);
+        const colorSet = getColorSet(config.colorSchemes[sourceID].mainPallete);
         trackColor = colorSet[track.id % colorSet.length];
       }
     }
   } else {
     if (config.showExonsFlag === false || highlight !== "plain") {
       if (!config.colorSchemes[1]) {
-        config.colorSchemes[1] = defaultHaplotypeColorPallete;
+        config.colorSchemes[1] = externalConfig.defaultHaplotypeColorPallete;
       }
       // don't repeat the color of the first track (reference) to highilight is better
       if (track.id === 0) {
-        trackColor = getColorSet(config.colorSchemes[1].mainPallate)[0];
+        trackColor = getColorSet(config.colorSchemes[1].mainPallete)[0];
       } else {
-        const colorSet = getColorSet(config.colorSchemes[1].mainPallate);
+        const colorSet = getColorSet(config.colorSchemes[1].mainPallete);
         trackColor = colorSet[((track.id - 1) % (colorSet.length - 1)) + 1];
       }
     } else {


### PR DESCRIPTION
Allow different selections of colors for reads and haplotypes. 
- Changed config field to store color variables using array and object, as opposed to individual fields
- Uses colors[0] to store haplotype colors, subsequent slots are for reads
- Colors array also stores colorbyMappingQuality for individual entries
    - currently updates all of them to the same value