### PR TITLE
Improve bad read layout

### DIFF
--- a/src/components/ExampleSelectButtons.js
+++ b/src/components/ExampleSelectButtons.js
@@ -71,6 +71,15 @@ class ExampleSelectButtons extends Component {
         >
           Aligned Reads
         </Button>
+        <Button
+          color="primary"
+          id="example7"
+          onClick={() =>
+            this.handleClick(dataOriginTypes.EXAMPLE_7, "greys", "reds")
+          }
+        >
+          Alignments to Reverse Nodes
+        </Button>
       </Form>
     );
   }

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -209,7 +209,7 @@ class TubeMapContainer extends Component {
         reads = tubeMap.vgExtractReads(
           nodes,
           tracks,
-          data.reverseAlignmentReads
+          data.mixedAlignmentReads
         );
         break;
       case dataOriginTypes.NO_DATA:

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -173,6 +173,7 @@ class TubeMapContainer extends Component {
     let tracks = [];
     let reads = [];
     let region = [];
+    let vg;
     const data = await import("../util/demo-data");
     nodes = data.inputNodes;
     switch (this.props.dataOrigin) {
@@ -192,13 +193,23 @@ class TubeMapContainer extends Component {
         tracks = data.inputTracks5;
         break;
       case dataOriginTypes.EXAMPLE_6:
-        const vg = JSON.parse(data.k3138);
+        vg = JSON.parse(data.k3138);
         nodes = tubeMap.vgExtractNodes(vg);
         tracks = tubeMap.vgExtractTracks(vg);
         reads = tubeMap.vgExtractReads(
           nodes,
           tracks,
           this.readsFromStringToArray(data.demoReads)
+        );
+        break;
+      case dataOriginTypes.EXAMPLE_7:
+        vg = data.reverseAlignmentGraph;
+        nodes = tubeMap.vgExtractNodes(vg);
+        tracks = tubeMap.vgExtractTracks(vg);
+        reads = tubeMap.vgExtractReads(
+          nodes,
+          tracks,
+          data.reverseAlignmentReads
         );
         break;
       case dataOriginTypes.NO_DATA:

--- a/src/enums.js
+++ b/src/enums.js
@@ -6,5 +6,6 @@ export const dataOriginTypes = {
   EXAMPLE_4: "example 4",
   EXAMPLE_5: "example 5",
   EXAMPLE_6: "example 6",
+  EXAMPLE_7: "example 7",
   NO_DATA: "no data",
 };

--- a/src/util/demo-data.js
+++ b/src/util/demo-data.js
@@ -111,3 +111,115 @@ export const demoReads = `
 {"sequence": "GGTACCCACTCCATAAGGTATTCAGCACCGCCGTGTCCCGGCCGGGTCGCGGGGAGCCCCGGTACATCGCAGTGGGCTACGTGGACGACACGCAGTTCGTGCGGTTCGACAGCGACGCGGCGACTCCGAGGATGTAGCCGCAGGCGCCGTGGTTGGAGCAGGAGGGACCGGAGTATTGGGACCGGAGCACACGGAACATCAGGCCCGCGCACAGACTGACAAGAGTGAACCTGCCCATGCCGCGCCGCTACTACCACCAGAGCTAGGCCGGTGAATGACCCCGGCCTGGGGCGAAGGTCACGACCCCTCCTCATCCCCCACGGACGTCCCGGGTCCCCCCCGCGAGTCTCCGGCTCC", "path": {"mapping": [{"position": {"offset": 1, "node_id": "2"}, "edit": [{"from_length": 3, "to_length": 3}], "rank": 1}, {"position": {"node_id": "4"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 2}, {"position": {"node_id": "5"}, "edit": [{"from_length": 16, "to_length": 16}], "rank": 3}, {"position": {"node_id": "8"}, "edit": [{"from_length": 10, "to_length": 10}], "rank": 5}, {"position": {"node_id": "9"}, "edit": [{"from_length": 29, "to_length": 29}], "rank": 6}, {"position": {"node_id": "10"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 7}, {"position": {"node_id": "12"}, "edit": [{"from_length": 2, "to_length": 2}], "rank": 8}, {"position": {"node_id": "13"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 9}, {"position": {"node_id": "14"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 10}, {"position": {"node_id": "15"}, "edit": [{"from_length": 6, "to_length": 6}], "rank": 11}, {"position": {"node_id": "16"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 12}, {"position": {"node_id": "18"}, "edit": [{"from_length": 10, "to_length": 10}], "rank": 13}, {"position": {"node_id": "19"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 14}, {"position": {"node_id": "21"}, "edit": [{"from_length": 3, "to_length": 3}], "rank": 15}, {"position": {"node_id": "23"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 16}, {"position": {"node_id": "24"}, "edit": [{"from_length": 10, "to_length": 10}], "rank": 17}, {"position": {"node_id": "25"}, "edit": [{"from_length": 5, "to_length": 5}], "rank": 18}, {"position": {"node_id": "26"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 19}, {"position": {"node_id": "28"}, "edit": [{"from_length": 26, "to_length": 26}], "rank": 20}, {"position": {"node_id": "29"}, "edit": [{"from_length": 2, "to_length": 2}], "rank": 21}, {"position": {"node_id": "30"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 22}, {"position": {"node_id": "32"}, "edit": [{"from_length": 29, "to_length": 29}], "rank": 23}, {"position": {"node_id": "33"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 24}, {"position": {"node_id": "34"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 25}, {"position": {"node_id": "35"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 26}, {"position": {"node_id": "36"}, "edit": [{"from_length": 8, "to_length": 8}], "rank": 27}, {"position": {"node_id": "37"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 28}, {"position": {"node_id": "39"}, "edit": [{"from_length": 23, "to_length": 23}], "rank": 29}, {"position": {"node_id": "40"}, "edit": [{"from_length": 7, "to_length": 7}], "rank": 30}]}, "score": 358, "identity": 1.0}
 {"sequence": "GGTTCCCACTCCATAAGGTAGTTCAGCACCGCCGTGTCCCGGCCGGGTCGCGGGGAGCCCCGGTACATCGCAGTGGGCTACGTGGACGACACGCAGTTCGTGCGGTTCGACAGCGACGCGGCGACTCCGAGGATGTAGCCGCAGGCGCCGTGGTTGGAGCAGGAGGGACCGGAGTATTGGGACCGGAGCACACGGAACATCAGGCCCGCGCACAGACTGACAAGAGTGAACCTGCCCATGCCGCGCCGCTACTACCACCAGAGCTAGGCCGGTGAATGACCCCGGCCTGGGGCGAAGGTCACGACCCCTCCTCATCCCCCACGGACGCCCCGGGTCCCCCCCGCGAGTCTCCGGCTCC", "path": {"mapping": [{"position": {"node_id": "3"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 2}, {"position": {"node_id": "5"}, "edit": [{"from_length": 16, "to_length": 16}], "rank": 3}, {"position": {"node_id": "6"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 4}, {"position": {"node_id": "8"}, "edit": [{"from_length": 10, "to_length": 10}], "rank": 5}, {"position": {"node_id": "9"}, "edit": [{"from_length": 29, "to_length": 29}], "rank": 6}, {"position": {"node_id": "10"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 7}, {"position": {"node_id": "12"}, "edit": [{"from_length": 2, "to_length": 2}], "rank": 8}, {"position": {"node_id": "13"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 9}, {"position": {"node_id": "14"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 10}, {"position": {"node_id": "15"}, "edit": [{"from_length": 6, "to_length": 6}], "rank": 11}, {"position": {"node_id": "16"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 12}, {"position": {"node_id": "18"}, "edit": [{"from_length": 10, "to_length": 10}], "rank": 13}, {"position": {"node_id": "19"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 14}, {"position": {"node_id": "21"}, "edit": [{"from_length": 3, "to_length": 3}], "rank": 15}, {"position": {"node_id": "23"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 16}, {"position": {"node_id": "24"}, "edit": [{"from_length": 10, "to_length": 10}], "rank": 17}, {"position": {"node_id": "25"}, "edit": [{"from_length": 5, "to_length": 5}], "rank": 18}, {"position": {"node_id": "26"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 19}, {"position": {"node_id": "28"}, "edit": [{"from_length": 26, "to_length": 26}], "rank": 20}, {"position": {"node_id": "29"}, "edit": [{"from_length": 2, "to_length": 2}], "rank": 21}, {"position": {"node_id": "30"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 22}, {"position": {"node_id": "32"}, "edit": [{"from_length": 29, "to_length": 29}], "rank": 23}, {"position": {"node_id": "33"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 24}, {"position": {"node_id": "34"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 25}, {"position": {"node_id": "35"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 26}, {"position": {"node_id": "36"}, "edit": [{"from_length": 8, "to_length": 8}], "rank": 27}, {"position": {"node_id": "38"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 28}, {"position": {"node_id": "39"}, "edit": [{"from_length": 23, "to_length": 23}], "rank": 29}, {"position": {"node_id": "40"}, "edit": [{"from_length": 7, "to_length": 7}], "rank": 30}]}, "score": 358, "identity": 1.0}
 `;
+
+export const reverseAlignmentGraph = {
+    "edge": [
+        {
+            "from": "60080783",
+            "from_start": true,
+            "to": "60080786",
+            "to_end": true
+        },
+        {
+            "from": "60080783",
+            "from_start": true,
+            "to": "60080785"
+        }
+    ],
+    "node": [
+        {
+            "id": "60080785",
+            "sequence": "AC"
+        },
+        {
+            "id": "60080783",
+            "sequence": "TT"
+        },
+        {
+            "id": "60080786",
+            "sequence": "GT"
+        }
+    ],
+    "path": [
+        {
+            "mapping": [
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080786"
+                    },
+                    "rank": "1"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 21,
+                            "to_length": 21
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080783"
+                    },
+                    "rank": "2"
+                }
+            ],
+            "name": "GRCh38.chr14",
+            "indexOfFirstBase": "0"
+        }
+    ]
+};
+
+export const reverseAlignmentReads = [
+    {
+        "identity": 1,
+        "name": "14d9f9588f5e9e52",
+        "path": {
+            "mapping": [
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080786"
+                    },
+                    "rank": "1"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "is_reverse": true,
+                        "node_id": "60080785"
+                    },
+                    "rank": "2"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080783"
+                    },
+                    "rank": "3"
+                },
+            ]
+        },
+        "score": 110,
+        "sequence": "GTGTTT"
+    }
+];

--- a/src/util/demo-data.js
+++ b/src/util/demo-data.js
@@ -124,6 +124,19 @@ export const reverseAlignmentGraph = {
             "from": "60080783",
             "from_start": true,
             "to": "60080785"
+        },
+        {
+            "from": "60080783",
+            "to": "60080785",
+        },
+        {
+            "from": "60080786",
+            "to": "60080785"
+        },
+        {
+            "from": "60080786",
+            "to": "60080785",
+            "to_end": true
         }
     ],
     "node": [
@@ -174,10 +187,58 @@ export const reverseAlignmentGraph = {
     ]
 };
 
-export const reverseAlignmentReads = [
+export const mixedAlignmentReads = [
     {
         "identity": 1,
-        "name": "14d9f9588f5e9e52",
+        "name": "Read1",
+        "path": {
+            "mapping": [
+                {
+                    "edit": [
+                        {
+                            "from_length": 1,
+                            "to_length": 1
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080786",
+                        "offset": 1
+                    },
+                    "rank": "1"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "is_reverse": true,
+                        "node_id": "60080785"
+                    },
+                    "rank": "2"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080783"
+                    },
+                    "rank": "3"
+                },
+            ]
+        },
+        "score": 110,
+        "sequence": "TGTTT"
+    },
+    {
+        "identity": 1,
+        "name": "Read2",
         "path": {
             "mapping": [
                 {
@@ -221,5 +282,98 @@ export const reverseAlignmentReads = [
         },
         "score": 110,
         "sequence": "GTGTTT"
+    },
+    {
+        "identity": 1,
+        "name": "Read3",
+        "path": {
+            "mapping": [
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080786"
+                    },
+                    "rank": "1"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080785"
+                    },
+                    "rank": "2"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080783"
+                    },
+                    "rank": "3"
+                },
+            ]
+        },
+        "score": 110,
+        "sequence": "GTACTT"
+    },
+    {
+        "identity": 1,
+        "name": "Read4",
+        "path": {
+            "mapping": [
+                {
+                    "edit": [
+                        {
+                            "from_length": 1,
+                            "to_length": 1
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080786",
+                        "offset": 1
+                    },
+                    "rank": "1"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080785"
+                    },
+                    "rank": "2"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080783"
+                    },
+                    "rank": "3"
+                },
+            ]
+        },
+        "score": 110,
+        "sequence": "GTACTT"
     }
 ];

--- a/src/util/demo-data.js
+++ b/src/util/demo-data.js
@@ -190,6 +190,53 @@ export const reverseAlignmentGraph = {
 export const mixedAlignmentReads = [
     {
         "identity": 1,
+        "name": "Read0",
+        "path": {
+            "mapping": [
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080786"
+                    },
+                    "rank": "1"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "is_reverse": true,
+                        "node_id": "60080785"
+                    },
+                    "rank": "2"
+                },
+                {
+                    "edit": [
+                        {
+                            "from_length": 2,
+                            "to_length": 2
+                        }
+                    ],
+                    "position": {
+                        "node_id": "60080783"
+                    },
+                    "rank": "3"
+                },
+            ]
+        },
+        "score": 110,
+        "sequence": "GTGTTT"
+    },
+    {
+        "identity": 1,
         "name": "Read1",
         "path": {
             "mapping": [
@@ -374,6 +421,6 @@ export const mixedAlignmentReads = [
             ]
         },
         "score": 110,
-        "sequence": "GTACTT"
+        "sequence": "TACTT"
     }
 ];

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -14,7 +14,7 @@ import externalConfig from "../config.json";
 
 const deepEqual = require("deep-equal");
 
-const DEBUG = false;
+const DEBUG = true;
 
 const greys = [
   "#d9d9d9",
@@ -153,8 +153,15 @@ export function create(params) {
   // optional parameters: bed, clickableNodes, reads, showLegend
   svgID = params.svgID;
   svg = d3.select(params.svgID);
-  inputNodes = JSON.parse(JSON.stringify(params.nodes)); // deep copy
-  inputTracks = JSON.parse(JSON.stringify(params.tracks)); // deep copy
+  inputNodes = deepCopy(params.nodes); // deep copy
+  // Nodes are referenced in inputs by internal `name` attribute and not by index.
+  // Internally in e.g. a path's indexSequence we need to reference nodes by *signed* index.
+  // Which means that index 0 can never be allowed to be used, so we need to make sure it is not there.
+  // So budge everything down
+  inputNodes.unshift(undefined);
+  // And then leave a hole in the array at 0 which we won't iterate over.
+  delete inputNodes[0];
+  inputTracks = deepCopy(params.tracks); // deep copy
   inputReads = params.reads || null;
   inputRegion = params.region;
   bed = params.bed || null;
@@ -162,6 +169,18 @@ export function create(params) {
   config.hideLegendFlag = params.hideLegend || false;
   const tr = createTubeMap();
   if (!config.hideLegendFlag) drawLegend(tr);
+}
+
+// Deep copy something, but preserve array holes at the top level
+function deepCopy(val) {
+  let newVal = JSON.parse(JSON.stringify(val));
+  for (let prop of Object.keys(newVal)) {
+    if (!Object.hasOwn(val, prop)) {
+      // This should be a hole, so punch it
+      delete newVal[prop];
+    }
+  }
+  return newVal;
 }
 
 // Return true if the given name names a reverse strand node, and false otherwise.
@@ -209,6 +228,7 @@ function moveTrackToFirstPosition(index) {
 
 // straighten track given by index by inverting inverted nodes
 // only keep them inverted if this single track runs thrugh them in both directions
+// TODO: This operates on `inputNodes`, etc. when it probably ought to operate on `nodes` 
 function straightenTrack(index) {
   let i;
   let j;
@@ -387,9 +407,9 @@ function createTubeMap() {
   if (inputNodes.length === 0 || inputTracks.length === 0) return;
 
   straightenTrack(0);
-  nodes = JSON.parse(JSON.stringify(inputNodes)); // deep copy (can add stuff to copy and leave original unchanged)
-  tracks = JSON.parse(JSON.stringify(inputTracks));
-  reads = JSON.parse(JSON.stringify(inputReads));
+  nodes = deepCopy(inputNodes); // deep copy (can add stuff to copy and leave original unchanged)
+  tracks = deepCopy(inputTracks);
+  reads = deepCopy(inputReads);
 
   reads = filterReads(reads);
 
@@ -1014,10 +1034,15 @@ function generateTrackIndexSequences(tracksOrReads) {
       if (nodes[nodeMap.get(forward(nodeName))].switched) {
         nodeName = flip(nodeName);
       }
+      let nodeIndex = nodeMap.get(forward(nodeName));
+      if (nodeIndex == 0) {
+        // If a node index is ever 0, we can't visit it in reverse, so we don't allow that to happen.
+        throw new Error('Node ' + forward(nodeName) + ' has prohibited index 0'); 
+      }
       if (isReverse(nodeName)) {
-        track.indexSequence.push(-nodeMap.get(forward(nodeName)));
+        track.indexSequence.push(-nodeIndex);
       } else {
-        track.indexSequence.push(nodeMap.get(forward(nodeName)));
+        track.indexSequence.push(nodeIndex);
       }
     });
   });
@@ -1028,7 +1053,7 @@ function removeUnusedNodes(allNodes) {
   const dNodes = allNodes.slice(0);
   let i;
   for (i = dNodes.length - 1; i >= 0; i -= 1) {
-    if (!dNodes[i].hasOwnProperty("x")) {
+    if (!dNodes[i] || !dNodes[i].hasOwnProperty("x")) {
       dNodes.splice(i, 1);
     }
   }
@@ -1526,51 +1551,88 @@ function generateNodeDegree() {
   });
 }
 
-// if more tracks pass through a specific node in reverse direction than in
-// regular direction, switch its orientation
-// (does not apply to the first track's nodes, these are always oriented as
-// dictated by the first track)
+// Optimize the orientations for nodes in the global `nodes` for displaying the
+// paths in the global `tracks` and the read paths, if applicable, in the
+// global `reads` 
 function switchNodeOrientation() {
+  let pivotPath = tracks[0];
+  let countPaths = tracks.slice(1, tracks.length);
+  if (reads && config.showReads) {
+    countPaths = countPaths.concat(reads);
+  }
+  switchNodeOrientationForPaths(countPaths, pivotPath);
+  if (reads && config.showReads) {
+    // Any changes should be committed back
+    for (let i = 0; i < reads.length; i++) {
+      if (reads[i] != countPaths[i + tracks.length - 1]) {
+        throw new Error("Read inequality");
+      }
+    }
+  }
+}
+
+// If more of the given paths pass through a specific node in reverse direction than in
+// regular direction, switch its orientation. Processes all paths' nodes in
+// place, so if you want e.g. a first track with nodes fixed in that
+// orientation, pass it as pivotPath.
+// References and modifies the global nodes variable.
+function switchNodeOrientationForPaths(paths, pivotPath) {
+
+  console.log('Switching node orientation for ' + (paths.length - 1) + ' paths');
+  
   const toSwitch = new Map();
   let nodeName;
   let prevNode;
   let nextNode;
   let currentNode;
 
-  for (let i = 1; i < tracks.length; i += 1) {
-    for (let j = 0; j < tracks[i].sequence.length; j += 1) {
-      nodeName = tracks[i].sequence[j];
+  for (let i = 0; i < paths.length; i += 1) {
+    for (let j = 0; j < paths[i].sequence.length; j += 1) {
+      nodeName = paths[i].sequence[j];
       nodeName = forward(nodeName);
       currentNode = nodes[nodeMap.get(nodeName)];
-      if (tracks[0].sequence.indexOf(nodeName) === -1) {
-        // do not change orientation for nodes which are part of the pivot track
+      if (pivotPath && pivotPath.sequence.indexOf(nodeName) === -1) {
+        // do not change orientation for nodes which are part of the pivot path
+        console.log('Node ' + nodeName + ' which is ' + currentNode + ' is not on the pivot path and could be flipped.');
         if (j > 0) {
-          prevNode = nodes[nodeMap.get(forward(tracks[i].sequence[j - 1]))];
+          prevNode = nodes[nodeMap.get(forward(paths[i].sequence[j - 1]))];
         }
-        if (j < tracks[i].sequence.length - 1) {
-          nextNode = nodes[nodeMap.get(forward(tracks[i].sequence[j + 1]))];
+        if (j < paths[i].sequence.length - 1) {
+          nextNode = nodes[nodeMap.get(forward(paths[i].sequence[j + 1]))];
         }
         if (
           (j === 0 || prevNode.order < currentNode.order) &&
-          (j === tracks[i].sequence.length - 1 ||
+          (j === paths[i].sequence.length - 1 ||
             currentNode.order < nextNode.order)
         ) {
+          // Node is visited in increasing order along the path
+          console.log('Node ' + nodeName + ' is visited in increasing order along the path');
           if (!toSwitch.has(nodeName)) toSwitch.set(nodeName, 0);
-          if (isReverse(tracks[i].sequence[j])) {
+          if (isReverse(paths[i].sequence[j])) {
+            // Node is reverse, so increment
+            console.log('Node ' + nodeName + ' is visited in reverse')
             toSwitch.set(nodeName, toSwitch.get(nodeName) + 1);
           } else {
+            // Node is forward, so decrement
+            console.log('Node ' + nodeName + ' is visited forward')
             toSwitch.set(nodeName, toSwitch.get(nodeName) - 1);
           }
         }
         if (
           (j === 0 || prevNode.order > currentNode.order) &&
-          (j === tracks[i].sequence.length - 1 ||
+          (j === paths[i].sequence.length - 1 ||
             currentNode.order > nextNode.order)
         ) {
+          // Node is visited in *decreasing* order along the path, so is already backward
+          console.log('Node ' + nodeName + ' is visited in decreasing order along the path');
           if (!toSwitch.has(nodeName)) toSwitch.set(nodeName, 0);
-          if (isReverse(tracks[i].sequence[j])) {
+          if (isReverse(paths[i].sequence[j])) {
+            // Node is reverse, so decrement
+            console.log('Node ' + nodeName + ' is visited in reverse')
             toSwitch.set(nodeName, toSwitch.get(nodeName) - 1);
           } else {
+            // Node is forward, so increment
+            console.log('Node ' + nodeName + ' is visited forward')
             toSwitch.set(nodeName, toSwitch.get(nodeName) + 1);
           }
         }
@@ -1578,13 +1640,15 @@ function switchNodeOrientation() {
     }
   }
 
-  tracks.forEach((track, trackIndex) => {
-    track.sequence.forEach((node, nodeIndex) => {
+  paths.forEach((path, pathIndex) => {
+    path.sequence.forEach((node, nodeIndex) => {
       nodeName = forward(node);
       if (toSwitch.has(nodeName) && toSwitch.get(nodeName) > 0) {
-        tracks[trackIndex].sequence[nodeIndex] = flip(node);
-        tracks[trackIndex].indexSequence[nodeIndex] =
-          -tracks[trackIndex].indexSequence[nodeIndex];
+        // This node is backward more so flip it around
+        console.log('Node ' + nodeName + ' ought to be flipped');
+        paths[pathIndex].sequence[nodeIndex] = flip(node);
+        paths[pathIndex].indexSequence[nodeIndex] =
+          -paths[pathIndex].indexSequence[nodeIndex];
       }
     });
   });
@@ -1593,7 +1657,9 @@ function switchNodeOrientation() {
   toSwitch.forEach((value, key) => {
     if (value > 0) {
       currentNode = nodeMap.get(key);
-      nodes[currentNode].seq = getReverseComplement(nodes[currentNode].seq);
+      let newSeq = getReverseComplement(nodes[currentNode].seq);
+      console.log('Change sequence of node ' + currentNode + ' from ' + nodes[currentNode].seq + ' to ' + newSeq);
+      nodes[currentNode].seq = newSeq;
       nodes[currentNode].switched = true;
     }
   });

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -1038,11 +1038,11 @@ function generateTrackIndexSequences(tracksOrReads) {
       // Get the index to visit the node. If the node is switched, this means
       // visiting it reverse. Otherwise, this means visiting it forward.
       let nodeIndex = nodeMap.get(forward(nodeName));
-      if (nodeIndex == 0) {
+      if (nodeIndex === 0) {
         // If a node index is ever 0, we can't visit it in reverse, so we don't allow that to happen.
         throw new Error('Node ' + forward(nodeName) + ' has prohibited index 0'); 
       }
-      if (isReverse(nodeName) != switched) {
+      if (isReverse(nodeName) !== switched) {
         // If we visit the node in reverse XOR the node is switched, go through
         // it right to left as displayed.
         track.indexSequence.push(-nodeIndex);
@@ -1572,7 +1572,7 @@ function switchNodeOrientation() {
   if (reads && config.showReads) {
     // Any changes should be committed back
     for (let i = 0; i < reads.length; i++) {
-      if (reads[i] != countPaths[i + tracks.length - 1]) {
+      if (reads[i] !== countPaths[i + tracks.length - 1]) {
         throw new Error("Read inequality");
       }
     }

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -1031,17 +1031,26 @@ function generateTrackIndexSequences(tracksOrReads) {
     track.sequence.forEach((nodeName) => {
       // if node was switched, reverse it here
       // Q? Is flipping the index enough? It looks like yes. Or should we also flip the node name in 'sequence'?
-      if (nodes[nodeMap.get(forward(nodeName))].switched) {
+      let switched = nodes[nodeMap.get(forward(nodeName))].switched || false;
+      if (switched) {
+        console.log('Visit to ' + nodeName + ' is a visit to a switched node so we should appear to visit ' + flip(nodeName));
         nodeName = flip(nodeName);
       }
+      // Get the index to visit the node. If the node is switched, this means
+      // visiting it reverse. Otherwise, this means visiting it forward.
       let nodeIndex = nodeMap.get(forward(nodeName));
       if (nodeIndex == 0) {
         // If a node index is ever 0, we can't visit it in reverse, so we don't allow that to happen.
         throw new Error('Node ' + forward(nodeName) + ' has prohibited index 0'); 
       }
-      if (isReverse(nodeName)) {
+      if (isReverse(nodeName) != switched) {
+        // If we visit the node in reverse XOR the node is switched, go through
+        // it right to left as displayed.
         track.indexSequence.push(-nodeIndex);
       } else {
+        // If either the node isn't switched and we go through it forward, or
+        // the node is switched *and* we go through it backward, go through it
+        // left to right as displayed. 
         track.indexSequence.push(nodeIndex);
       }
     });

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -3020,8 +3020,9 @@ function drawNodes(dNodes) {
 }
 
 function getPopUpText(node) {
+
   return (
-    `Node ID: ${node.name}\n` +
+    `Node ID: ${node.name}` + (node.switched ? ` (reversed)` : ``) + `\n` +
     `Node Length: ${node.sequenceLength} bases\n` +
     `Haplotypes: ${node.degree}\n` +
     `Aligned Reads: ${

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -14,7 +14,7 @@ import externalConfig from "../config.json";
 
 const deepEqual = require("deep-equal");
 
-const DEBUG = true;
+const DEBUG = false;
 
 const greys = [
   "#d9d9d9",
@@ -1033,7 +1033,6 @@ function generateTrackIndexSequences(tracksOrReads) {
       // Q? Is flipping the index enough? It looks like yes. Or should we also flip the node name in 'sequence'?
       let switched = nodes[nodeMap.get(forward(nodeName))].switched || false;
       if (switched) {
-        console.log('Visit to ' + nodeName + ' is a visit to a switched node so we should appear to visit ' + flip(nodeName));
         nodeName = flip(nodeName);
       }
       // Get the index to visit the node. If the node is switched, this means
@@ -1587,8 +1586,6 @@ function switchNodeOrientation() {
 // References and modifies the global nodes variable.
 function switchNodeOrientationForPaths(paths, pivotPath) {
 
-  console.log('Switching node orientation for ' + (paths.length - 1) + ' paths');
-  
   const toSwitch = new Map();
   let nodeName;
   let prevNode;
@@ -1602,7 +1599,6 @@ function switchNodeOrientationForPaths(paths, pivotPath) {
       currentNode = nodes[nodeMap.get(nodeName)];
       if (pivotPath && pivotPath.sequence.indexOf(nodeName) === -1) {
         // do not change orientation for nodes which are part of the pivot path
-        console.log('Node ' + nodeName + ' which is ' + currentNode + ' is not on the pivot path and could be flipped.');
         if (j > 0) {
           prevNode = nodes[nodeMap.get(forward(paths[i].sequence[j - 1]))];
         }
@@ -1615,15 +1611,12 @@ function switchNodeOrientationForPaths(paths, pivotPath) {
             currentNode.order < nextNode.order)
         ) {
           // Node is visited in increasing order along the path
-          console.log('Node ' + nodeName + ' is visited in increasing order along the path');
           if (!toSwitch.has(nodeName)) toSwitch.set(nodeName, 0);
           if (isReverse(paths[i].sequence[j])) {
             // Node is reverse, so increment
-            console.log('Node ' + nodeName + ' is visited in reverse')
             toSwitch.set(nodeName, toSwitch.get(nodeName) + 1);
           } else {
             // Node is forward, so decrement
-            console.log('Node ' + nodeName + ' is visited forward')
             toSwitch.set(nodeName, toSwitch.get(nodeName) - 1);
           }
         }
@@ -1633,15 +1626,12 @@ function switchNodeOrientationForPaths(paths, pivotPath) {
             currentNode.order > nextNode.order)
         ) {
           // Node is visited in *decreasing* order along the path, so is already backward
-          console.log('Node ' + nodeName + ' is visited in decreasing order along the path');
           if (!toSwitch.has(nodeName)) toSwitch.set(nodeName, 0);
           if (isReverse(paths[i].sequence[j])) {
             // Node is reverse, so decrement
-            console.log('Node ' + nodeName + ' is visited in reverse')
             toSwitch.set(nodeName, toSwitch.get(nodeName) - 1);
           } else {
             // Node is forward, so increment
-            console.log('Node ' + nodeName + ' is visited forward')
             toSwitch.set(nodeName, toSwitch.get(nodeName) + 1);
           }
         }
@@ -1654,7 +1644,6 @@ function switchNodeOrientationForPaths(paths, pivotPath) {
       nodeName = forward(node);
       if (toSwitch.has(nodeName) && toSwitch.get(nodeName) > 0) {
         // This node is backward more so flip it around
-        console.log('Node ' + nodeName + ' ought to be flipped');
         paths[pathIndex].sequence[nodeIndex] = flip(node);
         paths[pathIndex].indexSequence[nodeIndex] =
           -paths[pathIndex].indexSequence[nodeIndex];
@@ -1667,7 +1656,6 @@ function switchNodeOrientationForPaths(paths, pivotPath) {
     if (value > 0) {
       currentNode = nodeMap.get(key);
       let newSeq = getReverseComplement(nodes[currentNode].seq);
-      console.log('Change sequence of node ' + currentNode + ' from ' + nodes[currentNode].seq + ' to ' + newSeq);
       nodes[currentNode].seq = newSeq;
       nodes[currentNode].switched = true;
     }


### PR DESCRIPTION
This should improve  the situation in #240. There we had this:

![image](https://user-images.githubusercontent.com/5062495/225448416-39392d4c-aaf2-4dd0-b770-50a42e4b3154.png)

You can see that a lot of reads go through this node in reverse, and they are interleaved with the reads that bypass it.

Now I can get this:

![image](https://user-images.githubusercontent.com/5062495/225716546-7caec429-a6c8-4e1a-a9dd-0c6779dfba30.png)

The node is automatically flipped because it is mostly visited in reverse, and I fixed some bookkeeping that would break our signed-index visit representation for the 0th node.

The node's tooltip also explains that the node is being flipped around for display.

I think we can still get the problems in #240, which looks like it is really caused by interleaving reads that need to visit a node in reverse with reads that need to bypass that node, and also by each read that needs to visit a node in reverse needing its own dedicated X-axis lane on either side of the node, but us not having a way to push the other nodes apart to make space for this. But now, to get that, you would need reads to visit the node in both forward *and* reverse orientations. 