### PR TITLE
Plug in track settings

### DIFF
--- a/src/components/CustomizationAccordion.js
+++ b/src/components/CustomizationAccordion.js
@@ -169,15 +169,9 @@ class VisualizationOptions extends Component {
                 <h5>Colors</h5>
                 <Form>
                   <RadioRow
-                    rowHeading="Haplotypes Forward"
+                    rowHeading="Haplotypes"
                     color={visOptions.colorSchemes[1].mainPallete}
                     trackType="mainPallete"
-                    setColorSetting={this.setColorWithIndex(1)}
-                  />
-                  <RadioRow
-                    rowHeading="Haplotypes Reverse"
-                    color={visOptions.colorSchemes[1].auxPallete}
-                    trackType="auxPallete"
                     setColorSetting={this.setColorWithIndex(1)}
                   />
                   {visOptions.showReads && (

--- a/src/components/CustomizationAccordion.js
+++ b/src/components/CustomizationAccordion.js
@@ -11,7 +11,7 @@ import {
   Input,
   FormGroup,
 } from "reactstrap";
-import TrackSettingsButton from "./TrackSettingsButton";
+import TrackSettings from "./TrackSettings";
 
 class VisualizationOptions extends Component {
   state = {
@@ -165,17 +165,13 @@ class VisualizationOptions extends Component {
                     </React.Fragment>
                   )}
                 </FormGroup>
-
-                <h5>Colors</h5>
-                <Form>
-                  <TrackSettingsButton fileType="haplotype" trackColorSettings={visOptions.colorSchemes[1]} setTrackColorSetting={this.setColorWithIndex(1)} /> 
-                  {visOptions.showReads && (
-                      <React.Fragment>
-                        <TrackSettingsButton fileType="read" trackColorSettings={visOptions.colorSchemes[2]} setTrackColorSetting={this.setColorWithIndex(2)} />
-                        <TrackSettingsButton fileType="read" trackColorSettings={visOptions.colorSchemes[3]} setTrackColorSetting={this.setColorWithIndex(3)} />
-                      </React.Fragment>
-                    )}
-                </Form>
+                <TrackSettings label="Haplotype" fileType="haplotype" trackColorSettings={visOptions.colorSchemes[1]} setTrackColorSetting={this.setColorWithIndex(1)} /> 
+                {visOptions.showReads && (
+                    <React.Fragment>
+                      <TrackSettings label="GAM Index 1" fileType="read" trackColorSettings={visOptions.colorSchemes[2]} setTrackColorSetting={this.setColorWithIndex(2)} />
+                      <TrackSettings label="GAM Index 2" fileType="read" trackColorSettings={visOptions.colorSchemes[3]} setTrackColorSetting={this.setColorWithIndex(3)} />
+                    </React.Fragment>
+                  )}
               </CardBody>
             </Collapse>
           </Card>

--- a/src/components/CustomizationAccordion.js
+++ b/src/components/CustomizationAccordion.js
@@ -171,33 +171,33 @@ class VisualizationOptions extends Component {
                   <RadioRow
                     rowHeading="Haplotypes"
                     color={visOptions.colorSchemes[1].mainPallete}
-                    trackType="mainPallete"
+                    setting="mainPallete"
                     setColorSetting={this.setColorWithIndex(1)}
                   />
                   {visOptions.showReads && (
                       <React.Fragment>
                         <RadioRow
                           rowHeading="Gam1 Forward"
-                          color={visOptions.colorSchemes[2].mainPallete}
-                          trackType="mainPallete"
+                          setting={visOptions.colorSchemes[2].mainPallete}
+                          setting="mainPallete"
                           setColorSetting={this.setColorWithIndex(2)}
                         />
                         <RadioRow
                           rowHeading="Gam1 Reverse"
                           color={visOptions.colorSchemes[2].auxPallete}
-                          trackType="auxPallete"
+                          setting="auxPallete"
                           setColorSetting={this.setColorWithIndex(2)}
                         />
                         <RadioRow
                           rowHeading="Gam2 Forward"
                           color={visOptions.colorSchemes[3].mainPallete}
-                          trackType="mainPallete"
+                          setting="mainPallete"
                           setColorSetting={this.setColorWithIndex(3)}
                         />
                         <RadioRow
                           rowHeading="Gam2 Reverse"
                           color={visOptions.colorSchemes[3].auxPallete}
-                          trackType="auxPallete"
+                          setting="auxPallete"
                           setColorSetting={this.setColorWithIndex(3)}
                         />
                       </React.Fragment>

--- a/src/components/CustomizationAccordion.js
+++ b/src/components/CustomizationAccordion.js
@@ -11,7 +11,7 @@ import {
   Input,
   FormGroup,
 } from "reactstrap";
-import RadioRow from "./RadioRow";
+import TrackSettingsButton from "./TrackSettingsButton";
 
 class VisualizationOptions extends Component {
   state = {
@@ -168,38 +168,11 @@ class VisualizationOptions extends Component {
 
                 <h5>Colors</h5>
                 <Form>
-                  <RadioRow
-                    rowHeading="Haplotypes"
-                    color={visOptions.colorSchemes[1].mainPallete}
-                    setting="mainPallete"
-                    setColorSetting={this.setColorWithIndex(1)}
-                  />
+                  <TrackSettingsButton fileType="haplotype" trackColorSettings={visOptions.colorSchemes[1]} setTrackColorSetting={this.setColorWithIndex(1)} /> 
                   {visOptions.showReads && (
                       <React.Fragment>
-                        <RadioRow
-                          rowHeading="Gam1 Forward"
-                          setting={visOptions.colorSchemes[2].mainPallete}
-                          setting="mainPallete"
-                          setColorSetting={this.setColorWithIndex(2)}
-                        />
-                        <RadioRow
-                          rowHeading="Gam1 Reverse"
-                          color={visOptions.colorSchemes[2].auxPallete}
-                          setting="auxPallete"
-                          setColorSetting={this.setColorWithIndex(2)}
-                        />
-                        <RadioRow
-                          rowHeading="Gam2 Forward"
-                          color={visOptions.colorSchemes[3].mainPallete}
-                          setting="mainPallete"
-                          setColorSetting={this.setColorWithIndex(3)}
-                        />
-                        <RadioRow
-                          rowHeading="Gam2 Reverse"
-                          color={visOptions.colorSchemes[3].auxPallete}
-                          setting="auxPallete"
-                          setColorSetting={this.setColorWithIndex(3)}
-                        />
+                        <TrackSettingsButton fileType="read" trackColorSettings={visOptions.colorSchemes[2]} setTrackColorSetting={this.setColorWithIndex(2)} />
+                        <TrackSettingsButton fileType="read" trackColorSettings={visOptions.colorSchemes[3]} setTrackColorSetting={this.setColorWithIndex(3)} />
                       </React.Fragment>
                     )}
                 </Form>

--- a/src/components/RadioRow.js
+++ b/src/components/RadioRow.js
@@ -16,7 +16,7 @@ class RadioRow extends Component {
   onChange = (event) => {
 
     this.props.setColorSetting(
-      this.props.trackType,
+      this.props.setting,
       colorMap.get(event.target.value)
     );
 
@@ -56,7 +56,7 @@ RadioRow.propTypes = {
   color: PropTypes.string.isRequired,
   rowHeading: PropTypes.string.isRequired,
   setColorSetting: PropTypes.func.isRequired,
-  trackType: PropTypes.string.isRequired,
+  setting: PropTypes.string.isRequired,
   availableColors: PropTypes.array
 };
 

--- a/src/components/TrackSettings.js
+++ b/src/components/TrackSettings.js
@@ -50,14 +50,14 @@ export const TrackSettings = ({
                 return(
                     <Form>
                         <RadioRow
-                            rowHeading="Gam Forward"
+                            rowHeading="Forward Reads"
                             color={trackColorSettings.mainPallete}
                             setting="mainPallete"
                             setColorSetting={setTrackColorSetting}
                             availableColors={availableColors}
                         />
                         <RadioRow
-                            rowHeading="Gam Reverse"
+                            rowHeading="Reverse Reads"
                             color={trackColorSettings.auxPallete}
                             setting="auxPallete"
                             setColorSetting={setTrackColorSetting}

--- a/src/components/TrackSettings.js
+++ b/src/components/TrackSettings.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import PropTypes from "prop-types";
 import {
-    Container,
-    CardBody,
-    Card,
     Form,
   } from "reactstrap";
 import RadioRow from "./RadioRow";
@@ -29,6 +26,7 @@ export const TrackSettings = ({
     fileType,
     trackColorSettings,
     setTrackColorSetting,
+    label,
     availableColors
 }) => {
     function colorRenderSwitch(fileType) {
@@ -71,14 +69,10 @@ export const TrackSettings = ({
     }
 
     return(
-        <Container>
-            <Card>
-                <CardBody>
-                    <h5>Colors</h5>
-                    {colorRenderSwitch(fileType)}
-                </CardBody>
-            </Card>
-        </Container>
+        <>
+          <h5>{label} Colors</h5>
+          {colorRenderSwitch(fileType)}
+        </>
     )
 }
 
@@ -86,6 +80,7 @@ TrackSettings.propTypes = {
     fileType: PropTypes.string.isRequired,
     trackColorSettings: PropTypes.object.isRequired,
     setTrackColorSetting: PropTypes.func.isRequired,
+    label: PropTypes.string,
     availableColors: PropTypes.array
 }
 

--- a/src/components/TrackSettings.js
+++ b/src/components/TrackSettings.js
@@ -38,7 +38,7 @@ export const TrackSettings = ({
                 return(
                     <Form>
                         <RadioRow
-                            rowHeading="Haplotypes Forward"
+                            rowHeading="Haplotypes"
                             color={trackColorSettings.mainPallete}
                             trackType="mainPallete"
                             setColorSetting={setTrackColorSetting}

--- a/src/components/TrackSettings.js
+++ b/src/components/TrackSettings.js
@@ -40,7 +40,7 @@ export const TrackSettings = ({
                         <RadioRow
                             rowHeading="Haplotypes"
                             color={trackColorSettings.mainPallete}
-                            trackType="mainPallete"
+                            setting="mainPallete"
                             setColorSetting={setTrackColorSetting}
                             availableColors={availableColors}
                         />
@@ -52,14 +52,14 @@ export const TrackSettings = ({
                         <RadioRow
                             rowHeading="Gam Forward"
                             color={trackColorSettings.mainPallete}
-                            trackType="mainPallete"
+                            setting="mainPallete"
                             setColorSetting={setTrackColorSetting}
                             availableColors={availableColors}
                         />
                         <RadioRow
                             rowHeading="Gam Reverse"
                             color={trackColorSettings.auxPallete}
-                            trackType="auxPallete"
+                            setting="auxPallete"
                             setColorSetting={setTrackColorSetting}
                             availableColors={availableColors}
                         />

--- a/src/components/TrackSettingsButton.js
+++ b/src/components/TrackSettingsButton.js
@@ -10,7 +10,7 @@ export const TrackSettingsButton = ({
     availableColors
 }) => {
     return(
-        <Popup trigger={<button> Settings </button>} position="right center"> 
+        <Popup trigger={<button type="button"> Settings </button>} position="right center"> 
             <TrackSettings 
             fileType={fileType}
             trackColorSettings={trackColorSettings}
@@ -25,6 +25,10 @@ TrackSettingsButton.propTypes = {
     trackColorSettings: PropTypes.object.isRequired,
     setTrackColorSetting: PropTypes.func.isRequired,
     availableColors: PropTypes.array
+}
+
+TrackSettingsButton.defaultProps = {
+    availableColors: ["greys", "ygreys", "blues", "reds", "plainColors", "lightColors"]
 }
 
 export default TrackSettingsButton;

--- a/src/components/TrackSettingsButton.js
+++ b/src/components/TrackSettingsButton.js
@@ -10,7 +10,7 @@ export const TrackSettingsButton = ({
     availableColors
 }) => {
     return(
-        <Popup trigger={<button type="button"> Settings </button>} position="right center"> 
+        <Popup trigger={<button type="button"> Settings </button>} position="right center" modal> 
             <TrackSettings 
             fileType={fileType}
             trackColorSettings={trackColorSettings}

--- a/src/components/TrackSettingsButton.js
+++ b/src/components/TrackSettingsButton.js
@@ -2,20 +2,33 @@ import React from 'react';
 import Popup from 'reactjs-popup';
 import PropTypes from "prop-types";
 import TrackSettings from "./TrackSettings.js";
+import {
+  Container,
+  CardBody,
+  Card,
+} from 'reactstrap';
 
 export const TrackSettingsButton = ({
     fileType,
     trackColorSettings,
     setTrackColorSetting,
+    label,
     availableColors
 }) => {
     return(
-        <Popup trigger={<button type="button"> Settings </button>} position="right center" contentStyle={{width: "760px"}} modal> 
-            <TrackSettings 
-            fileType={fileType}
-            trackColorSettings={trackColorSettings}
-            availableColors={availableColors}
-            setTrackColorSetting={setTrackColorSetting}/>
+        <Popup trigger={<button type="button"> Settings </button>} position="right center" contentStyle={{width: "760px"}} modal>
+          <Container>
+            <Card>
+              <CardBody>
+                  <TrackSettings
+                    fileType={fileType}
+                    trackColorSettings={trackColorSettings}
+                    availableColors={availableColors}
+                    setTrackColorSetting={setTrackColorSetting}
+                    label={label}/>
+              </CardBody>
+            </Card>
+          </Container>
         </Popup>
     )
 }
@@ -24,7 +37,8 @@ TrackSettingsButton.propTypes = {
     fileType: PropTypes.string.isRequired,
     trackColorSettings: PropTypes.object.isRequired,
     setTrackColorSetting: PropTypes.func.isRequired,
-    availableColors: PropTypes.array
+    label: PropTypes.string,
+    availableColors: PropTypes.array,
 }
 
 TrackSettingsButton.defaultProps = {

--- a/src/components/TrackSettingsButton.js
+++ b/src/components/TrackSettingsButton.js
@@ -10,7 +10,7 @@ export const TrackSettingsButton = ({
     availableColors
 }) => {
     return(
-        <Popup trigger={<button type="button"> Settings </button>} position="right center" modal> 
+        <Popup trigger={<button type="button"> Settings </button>} position="right center" contentStyle={{width: "760px"}} modal> 
             <TrackSettings 
             fileType={fileType}
             trackColorSettings={trackColorSettings}


### PR DESCRIPTION
This plugs in the track settings forms and gets rid of the reverse haplotype color setting.

I had to change the track settings dialogs to modals because of https://github.com/yjose/reactjs-popup/issues/334, and they don't look as good like that, because then the position is ignored and they just end up in the center of the screen.