### PR TITLE
Move available tracks and colors out of per-track object

### DIFF
--- a/src/components/TrackListItem.demo.js
+++ b/src/components/TrackListItem.demo.js
@@ -10,16 +10,19 @@ export default (<Demo
     trackProps: P.json({
       trackFile: undefined,
       trackType: "graph",
-      availableTracks: [{"files": [{"name": "fileA1.vg", "type": "graph"},
-                                          {"name": "fileA2.gbwt", "type": "haplotype"}]},
-                               {"files": [{"name": "fileB1.gbwt", "type": "haplotype"},
-                                          {"name": "fileB2.gam", "type": "read"}]},
-                               {"files": [{"name": "fileC1.xg", "type": "graph"}]}],
       trackColorSettings: {    
         mainPallete: "blues",
         auxPallete: "reds",
-        colorReadsByMappingQuality: false},
-    })
+        colorReadsByMappingQuality: false
+      }
+    }),
+    availableTracks: P.json([
+      {"files": [{"name": "fileA1.vg", "type": "graph"},
+                 {"name": "fileA2.gbwt", "type": "haplotype"}]},
+      {"files": [{"name": "fileB1.gbwt", "type": "haplotype"},
+                 {"name": "fileB2.gam", "type": "read"}]},
+      {"files": [{"name": "fileC1.xg", "type": "graph"}]}
+    ])
   }}
 >
   {

--- a/src/components/TrackListItem.js
+++ b/src/components/TrackListItem.js
@@ -12,13 +12,15 @@ import React, { useEffect, useReducer, useRef } from 'react';
 
 
 export const TrackListItem = ({
+    // trackProps expects an object with:
+    // * trackType: string
+    // * trackFile: file object / undefined
+    // * trackColorSettings: object(aka. colorScheme)
     trackProps,
-    // trackProps expects an object with
-      // trackType: string
-      // trackFile: file object / undefined
-      // availableTracks: array of tracks(see types.ts)
-      // trackColorSettings: object(aka. colorScheme)
-      // availableColors: array of ColorPalletes
+    // availableTracks: array of tracks(see types.ts)
+    availableTracks,
+    // availableColors: array of ColorPalletes
+    availableColors,
     onChange, // expects a new trackProps object
     onDelete,
   }) => {
@@ -78,7 +80,7 @@ export const TrackListItem = ({
                               />
           </Col>
           <Col className="tracklist-dropdown" sm="3">
-            <TrackFilePicker tracks={myTrackProps["availableTracks"]} 
+            <TrackFilePicker tracks={availableTracks} 
                             fileType={myTrackProps["trackType"]} 
                             value={myTrackProps["trackFile"]}
                             pickerType={"dropdown"} 
@@ -89,7 +91,7 @@ export const TrackListItem = ({
             <TrackSettingsButton fileType={myTrackProps["trackType"]}
                                 trackColorSettings={myTrackProps["trackColorSettings"]}
                                 setTrackColorSetting={trackSettingsOnChange}
-                                availableColors={trackProps["availableColors"]}
+                                availableColors={availableColors}
                                 />
             <TrackDeleteButton onClick={onDelete}
                               />
@@ -103,6 +105,8 @@ export const TrackListItem = ({
   
   TrackListItem.propTypes = {
     trackProps: PropTypes.object.isRequired,
+    availableTracks: PropTypes.array.isRequired,
+    availableColors: PropTypes.array,
     onChange: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
   }

--- a/src/components/TrackListItem.test.js
+++ b/src/components/TrackListItem.test.js
@@ -27,10 +27,10 @@ describe('TrackSettings', () => {
               trackProps={{
                 trackFile: trackFile,
                 trackType: trackType,
-                availableColors: availableColors,
-                availableTracks: availableTracks,
                 trackColorSettings: trackColorSettings
               }}
+              availableColors = {availableColors}
+              availableTracks = {availableTracks}
               onChange = {fakeOnChange}
               onDelete = {fakeOnDelete}
              />
@@ -55,10 +55,10 @@ describe('TrackSettings', () => {
             trackProps={{
                 trackFile: trackFile,
                 trackType: trackType,
-                availableColors: availableColors,
-                availableTracks: availableTracks,
                 trackColorSettings: trackColorSettings
               }}
+              availableColors = {availableColors}
+              availableTracks = {availableTracks}
               onChange = {fakeOnChange}
               onDelete = {fakeOnDelete}
              />
@@ -81,10 +81,10 @@ describe('TrackSettings', () => {
             trackProps={{
                 trackFile: trackFile,
                 trackType: "haplotype",
-                availableColors: availableColors,
-                availableTracks: availableTracks,
                 trackColorSettings: trackColorSettings
               }}
+              availableColors = {availableColors}
+              availableTracks = {availableTracks}
               onChange = {fakeOnChange}
               onDelete = {fakeOnDelete}
              />
@@ -100,8 +100,6 @@ describe('TrackSettings', () => {
         expect(fakeOnChange).toHaveBeenCalledWith({
             trackFile: {"name": "fileB1.gbwt", "type": "haplotype"},
             trackType: "haplotype",
-            availableColors: availableColors,
-            availableTracks: availableTracks,
             trackColorSettings: trackColorSettings
         });
 
@@ -125,10 +123,10 @@ describe('TrackSettings', () => {
             trackProps={{
                 trackFile: trackFile,
                 trackType: trackType,
-                availableColors: availableColors,
-                availableTracks: availableTracks,
                 trackColorSettings: trackColorSettings
               }}
+              availableColors = {availableColors}
+              availableTracks = {availableTracks}
               onChange = {fakeOnChange}
               onDelete = {fakeOnDelete}
              />


### PR DESCRIPTION
This adjusts the `TrackListItem` to separate out the stuff to do with the track it is controlling from the stuff to do with the collection of available tracks and colors.