### PR TITLE
Install a compact test reporter for jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "websocket": "^1.0.34"
       },
       "devDependencies": {
+        "jest-compact-reporter": "^1.2.9",
         "jest-fetch-mock": "^3.0.3",
         "prettier": "^2.7.1",
         "qs": "^6.11.0"
@@ -5073,6 +5074,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "node_modules/assert-never": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
+      "dev": true
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
@@ -10403,6 +10410,15 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-compact-reporter": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/jest-compact-reporter/-/jest-compact-reporter-1.2.9.tgz",
+      "integrity": "sha512-s8SsyiFQu9aniDyZ/t7FAEVxjMzUryHM7e1Leef4DZwyDCNJyGUclREJyvi4cN9yCtu7PSXx3ms47OqpFzUA4w==",
+      "dev": true,
+      "dependencies": {
+        "assert-never": "^1.2.1"
       }
     },
     "node_modules/jest-config": {
@@ -20612,6 +20628,12 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "assert-never": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
+      "dev": true
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -24614,6 +24636,15 @@
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
+      }
+    },
+    "jest-compact-reporter": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/jest-compact-reporter/-/jest-compact-reporter-1.2.9.tgz",
+      "integrity": "sha512-s8SsyiFQu9aniDyZ/t7FAEVxjMzUryHM7e1Leef4DZwyDCNJyGUclREJyvi4cN9yCtu7PSXx3ms47OqpFzUA4w==",
+      "dev": true,
+      "requires": {
+        "assert-never": "^1.2.1"
       }
     },
     "jest-config": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "start": "concurrently -n frontend,backend -c red,green 'HOST=${HOST:=127.0.0.1} PORT=${PORT:=3001} react-scripts start' 'npm:serve'",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --reporters default --reporters jest-compact-reporter",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
@@ -72,6 +72,7 @@
     "node": ">=10.0.0"
   },
   "devDependencies": {
+    "jest-compact-reporter": "^1.2.9",
     "jest-fetch-mock": "^3.0.3",
     "prettier": "^2.7.1",
     "qs": "^6.11.0"


### PR DESCRIPTION
This PR just adds `jest-compact-reporter` as a reporter in addition to the default reporter.

It will cause `npm run test` to output Jest's default report followed by a summary of which tests passed and failed.