### PR TITLE
Add --seed to terminate --reporters parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "start": "concurrently -n frontend,backend -c red,green 'HOST=${HOST:=127.0.0.1} PORT=${PORT:=3001} react-scripts start' 'npm:serve'",
     "build": "react-scripts build",
-    "test": "react-scripts test --reporters default --reporters jest-compact-reporter",
+    "test": "react-scripts test --reporters default jest-compact-reporter --watchAll=true",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "start": "concurrently -n frontend,backend -c red,green 'HOST=${HOST:=127.0.0.1} PORT=${PORT:=3001} react-scripts start' 'npm:serve'",
     "build": "react-scripts build",
-    "test": "react-scripts test --reporters default jest-compact-reporter --watchAll=true",
+    "test": "react-scripts test --reporters default jest-compact-reporter --seed=1",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",


### PR DESCRIPTION
This fixes:
```
npm run test -- src/components/HelpButton.test.js
```

It adds a no-op option (setting `--watchAll` to its default) to stop `--reporters` eating the positional arguments.

You can still override it the normal way, because the last option wins:
```
npm run test -- --watchAll=false src/components/HelpButton.test.js
```

I think this will close https://github.com/vgteam/sequenceTubeMap/pull/263 because now we can just use `npm run test` all the time and always have the nice summary reporter, and we won't need a separate `npm run ci:test`.