### PR TITLE
Support colons in contigs and polyglot-ify to allow shared client-server imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "d3-selection-multi": "^1.0.1",
         "deep-equal": "^2.2.1",
         "dotenv": "^16.0.3",
+        "es-dirname": "^0.1.0",
         "express": "^4.18.2",
         "fs-extra": "^10.1.0",
         "gh-pages": "^4.0.0",
@@ -62,7 +63,7 @@
         "qs": "^6.11.1"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -8322,6 +8323,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+    },
+    "node_modules/es-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/es-dirname/-/es-dirname-0.1.0.tgz",
+      "integrity": "sha512-tcTj4pVFXe5EdiHCybjynDTlvkwuNN6JCg9+5BVB+n9qQoMyWOtxpREoL7rGO3sCIAX55Y6CYZi4s1c30uxvPg=="
     },
     "node_modules/es-get-iterator": {
       "version": "1.1.3",
@@ -25556,6 +25562,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+    },
+    "es-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/es-dirname/-/es-dirname-0.1.0.tgz",
+      "integrity": "sha512-tcTj4pVFXe5EdiHCybjynDTlvkwuNN6JCg9+5BVB+n9qQoMyWOtxpREoL7rGO3sCIAX55Y6CYZi4s1c30uxvPg=="
     },
     "es-get-iterator": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "d3-selection-multi": "^1.0.1",
     "deep-equal": "^2.2.1",
     "dotenv": "^16.0.3",
+    "es-dirname": "^0.1.0",
     "express": "^4.18.2",
     "fs-extra": "^10.1.0",
     "gh-pages": "^4.0.0",
@@ -57,8 +58,8 @@
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "serve": "node ./src/server.js",
-    "format": "prettier --write \"**/*.+(js|css)\""
+    "serve": "node ./src/server.mjs",
+    "format": "prettier --write \"**/*.+(mjs|js|css)\""
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -70,7 +71,7 @@
     "not op_mini all"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "jest-compact-reporter": "^1.2.9",

--- a/src/common.mjs
+++ b/src/common.mjs
@@ -1,0 +1,92 @@
+// common.mjs: shared functions between client and server
+
+// function to remove commas from coordinate input
+const removeCommas = (input) => {
+  let parts = input.split(":");
+  if (parts.length < 2){
+    return input;
+  }
+  // get coordinate - numerical range after last colon
+  let coordinates = parts[parts.length - 1];
+  coordinates = coordinates.replace(/,/g, "");
+  // put region input coordinate back together
+  parts[parts.length - 1] = coordinates;
+  let fixedInputValue = parts.join(":");
+  return fixedInputValue;
+};
+
+// Parse a region string into:
+// { contig, start, end }
+// or
+// { contig, start, distance }
+//
+// For distance, + is used as the coordinate separator. For start/end ranges, - is used.
+// The coordinates are set off from the contig by the last colon.
+// Commas in coordinates are removed.
+//
+// Throws an Error if the region was not understood.
+export function parseRegion(region) {
+  if (!region || region === "none") {
+    throw new Error("Missing region.");
+  }
+  if (!region.includes(":")) {
+    throw new Error("Region doesn't contain a ':'.");
+  }
+  if (region.endsWith(":")) {
+    throw new Error("Region ends with a ':' and is missing coordinates.");
+  }
+
+  region = removeCommas(region);
+
+  // Get the part of the region after the last colon
+  let region_col = region.split(":");
+  let start_end = region_col[region_col.length - 1].split("-");
+  let pos_dist = region_col[region_col.length - 1].split("+");
+
+  let contig = region_col.slice(0, -1).join(':');
+
+  if (start_end.length === 2) {
+    let start = Number(start_end[0]);
+    let end = Number(start_end[1]);
+    return { contig, start, end };
+  } else if (pos_dist.length === 2) {
+    let start = Number(pos_dist[0]);
+    let distance = Number(pos_dist[1]);
+    return {contig, start, distance };
+  } else {
+    throw new Error("Coordinates must be in the form 'X:Y-Z' or 'X:Y+Z'.");
+  }
+  
+}
+
+/// Return a version of region that is {contig, start, end} even if region is {contig, start, distance}
+export function convertRegionToRangeRegion(region) {
+  if (region.distance !== undefined) {
+    // Has a distance and not an end.
+    return {
+      contig: region.contig,
+      start: region.start,
+      end: region.start + region.distance
+    };
+  } else {
+    // Should already have an end.
+    return region;
+  }
+}
+
+// Take a { contig, start, end} region and turn it into a
+// string compatible with parseRegion() or with vg.
+export function stringifyRangeRegion({contig, start, end}) {
+  return contig.concat(':', start, '-', end);
+}
+
+// Take a {contig, start, end} or {contig, start, distance} region and turn it into a string compatible with parseRegion
+export function stringifyRegion(region) {
+  if (region.distance !== undefined) {
+    // It is a distance-based region
+    return region.contig.concat(':', region.start, '+', region.distance);
+  } else {
+    // It is a range region
+    return stringifyRangeRegion(region);
+  }
+}

--- a/src/end-to-end.test.js
+++ b/src/end-to-end.test.js
@@ -23,9 +23,6 @@ import userEvent from "@testing-library/user-event";
 import selectEvent from "react-select-event";
 import App from "./App";
 
-
-console.log("Loading server:", server);
-
 const getRegionInput = () => {
   // Helper function to select the Region input box
   return screen.getByRole("combobox", { name: /Region/i });

--- a/src/end-to-end.test.js
+++ b/src/end-to-end.test.js
@@ -1,6 +1,11 @@
 // End to end tests that test the frontend against a backend over HTTP
 
-import server from "./server";
+// Normal import doesn't work here; something to do with the multiple
+// not-really-standard implementations of JS modules in play. So we import the
+// server's start function and put it in an object pretendign to be a module.
+import { start } from "./server.mjs";
+const server = { start };
+
 import React from "react";
 // testing-library provides a render() that auto-cleans-up from the global DOM.
 import {
@@ -17,6 +22,9 @@ import "@testing-library/jest-dom/extend-expect";
 import userEvent from "@testing-library/user-event";
 import selectEvent from "react-select-event";
 import App from "./App";
+
+
+console.log("Loading server:", server);
 
 const getRegionInput = () => {
   // Helper function to select the Region input box

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -16,8 +16,10 @@ import pathIsInside from "path-is-inside";
 import rl from "readline";
 import compression from "compression";
 import { server as WebSocketServer } from "websocket";
+import dotenv from "dotenv";
+import dirname from "es-dirname";
+import { readFileSync } from 'fs';
 import { parseRegion, convertRegionToRangeRegion, stringifyRangeRegion, stringifyRegion } from "./common.mjs";
-//import esMain from 'es-main';
 
 // Now we want to load config.json.
 //
@@ -38,26 +40,17 @@ import { parseRegion, convertRegionToRangeRegion, stringifyRangeRegion, stringif
 //
 // So we try a filesystem load.
 // See <https://stackoverflow.com/a/75705665>
-// But we can't use top-level await.
+// But we can't use top-level await, so it has to be synchronous.
 //
 // We also can't say "__dirname" or "import.meta" even to poll if those exist,
-// or node and babel (respectively) will yell at us.
-// Luckily this module exists which can find *our* directory by looking at the stack.
-// See https://github.com/vdegenne/es-dirname/blob/master/es-dirname.js
-import dirname from 'es-dirname'
-
-import { readFileSync } from 'fs';
+// or node and Babel (respectively) will yell at us.
+// Luckily the es-dirname module exists which can find *our* directory by
+// looking at the stack. See
+// https://github.com/vdegenne/es-dirname/blob/master/es-dirname.js
 const config = JSON.parse(readFileSync(dirname() + '/config.json'));
 
-
-// So we will go back to require for this JSON specifically.
-// See <https://stackoverflow.com/a/75705665>
-//import { createRequire } from "module";
-//const require = createRequire(import.meta.url);
-//const config = require("./config.json");
-
-import dotenv from "dotenv";
 if (process.env.NODE_ENV !== "production") {
+  // Load any .env file config
   dotenv.config();
 }
 


### PR DESCRIPTION
This uses cheating and hackery to allow files with the extension ".mjs" to be importable by both the client *and* the server code. As long as they are written using import, but never try to touch import.meta or import assertions or require or the other CommonJS things like __dirname, they will be acceptable both to Node on the server side and to Babel on the client side and to Jest during the tests.

I am using this to centralize the parsing/unparsing of region strings, so we can be using the same code throughout and thus not get into trouble with colons in the contig being supported in some places but not in others.

This will fix #284.