### PR TITLE
Fix tube map rerendering when item info dialog opens and closes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -152,16 +152,16 @@ class App extends Component {
       let newcolors = [...state.visOptions.colorSchemes]
       if (newcolors[index] === undefined) {
         // Handle the set call from example data maybe coming before we set up any nonempty real tracks.
-        // TODO: COme up with a better way to do this.
+        // TODO: Come up with a better way to do this.
         newcolors[index] = {...config.defaultReadColorPalette};
       }
-      newcolors[index][key] = value;
+      newcolors[index] = {...newcolors[index], [key]: value};
       console.log('Set index ' + index + ' key ' + key + ' to ' + value);
       console.log('New colors: ', newcolors);
       return {
         visOptions: {
           ...state.visOptions,
-          colors: newcolors,
+          colorSchemes: newcolors,
         },
       };
     });

--- a/src/components/TubeMap.js
+++ b/src/components/TubeMap.js
@@ -1,14 +1,23 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import * as tubeMap from "../util/tubemap";
+import isEqual from "react-fast-compare";
 
 class TubeMap extends Component {
   componentDidMount() {
+    this.updateVisOptions();
     this.createTubeMap();
   }
 
-  componentDidUpdate() {
-    this.createTubeMap();
+  componentDidUpdate(prevProps) {
+    console.log('Props:', this.props);
+    if (!isEqual(this.props, prevProps)) {
+      console.log('Props have changed so re-creating tube map');
+      this.updateVisOptions();
+      this.createTubeMap();
+    } else {
+      console.log('Props have not changed so leaving existing tube map');
+    }
   }
 
   createTubeMap = () => {
@@ -18,8 +27,30 @@ class TubeMap extends Component {
       tracks: this.props.tracks,
       reads: this.props.reads,
       region: this.props.region,
+      visOptions: this.props.visOptions,
     });
   };
+
+  updateVisOptions() {
+    const visOptions = this.props.visOptions;
+    visOptions.compressedView
+      ? tubeMap.setNodeWidthOption(1)
+      : tubeMap.setNodeWidthOption(0);
+    tubeMap.setMergeNodesFlag(visOptions.removeRedundantNodes);
+    tubeMap.setTransparentNodesFlag(visOptions.transparentNodes);
+    tubeMap.setShowReadsFlag(visOptions.showReads);
+    tubeMap.setSoftClipsFlag(visOptions.showSoftClips);
+
+    // apply new colorReadsByMappingQuality value to all tracks
+    // to be changed, add options to change colorReadsByMappingQuality individually
+    tubeMap.setColorReadsByMappingQualityFlag(visOptions.colorReadsByMappingQuality);
+
+    for (let i = 0; i < visOptions.colorSchemes.length; i++) {
+      // update tubemap colors
+      tubeMap.setColorSet(i, visOptions.colorSchemes[i]);
+    }
+    tubeMap.setMappingQualityCutoff(visOptions.mappingQualityCutoff);
+  }  
 
   render() {
     return <svg id="svg" alt="Rendered sequence tube map visualization" />;
@@ -31,6 +62,7 @@ TubeMap.propTypes = {
   tracks: PropTypes.array.isRequired,
   reads: PropTypes.array.isRequired,
   region: PropTypes.array.isRequired,
+  visOptions: PropTypes.object.isRequired
 };
 
 export default TubeMap;

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -58,32 +58,11 @@ class TubeMapContainer extends Component {
     }
     // updating visOptions will cause an error if the tubemap is not in place yet.
     if(!this.state.isLoading) {
-      this.updateVisOptions();
+      // Hook into item clicks form the tube map
       tubeMap.setInfoCallback((text) => {
         this.setState({infoDialogContent: text});
       });
     }
-  }
-
-  updateVisOptions() {
-    const visOptions = this.props.visOptions;
-    visOptions.compressedView
-      ? tubeMap.setNodeWidthOption(1)
-      : tubeMap.setNodeWidthOption(0);
-    tubeMap.setMergeNodesFlag(visOptions.removeRedundantNodes);
-    tubeMap.setTransparentNodesFlag(visOptions.transparentNodes);
-    tubeMap.setShowReadsFlag(visOptions.showReads);
-    tubeMap.setSoftClipsFlag(visOptions.showSoftClips);
-
-    // apply new colorReadsByMappingQuality value to all tracks
-    // to be changed, add options to change colorReadsByMappingQuality individually
-    tubeMap.setColorReadsByMappingQualityFlag(visOptions.colorReadsByMappingQuality);
-
-    for (let i = 0; i < visOptions.colorSchemes.length; i++) {
-      // update tubemap colors
-      tubeMap.setColorSet(i, visOptions.colorSchemes[i]);
-    }
-    tubeMap.setMappingQualityCutoff(visOptions.mappingQualityCutoff);
   }
 
   render() {
@@ -139,6 +118,7 @@ class TubeMapContainer extends Component {
             tracks={this.state.tracks}
             reads={this.state.reads}
             region={this.state.region}
+            visOptions={this.props.visOptions}
           />
         </div>
       </div>

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -395,6 +395,7 @@ export function setMappingQualityCutoff(value) {
 
 // main
 function createTubeMap() {
+  console.log('Recreating tube map in', svgID);
   trackRectangles = [];
   trackCurves = [];
   trackCorners = [];


### PR DESCRIPTION
We now check to make sure that the tube map's determining props actually changed before going to re-render it.

Also, we now no longer rewrite the color schemes in place and instead properly return a new object with the new stuff under the right key.

This moves visOptions into the props of the tube map itself, because when they change the tube map needs to redraw.

We might now be able to cut some redraw calls from the setters for them in tubemap.js.