### PR TITLE
Add devcontainer config to support Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,10 @@
   "forwardPorts": [3000],
   "features": {
     "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers-contrib/features/bash-command:1": {
+      "command": "echo 'if [[ ! -z \"$GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN\" ]] ; then export WDS_SOCKET_HOST=\"${CODESPACE_NAME}-3000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; export WDS_SOCKET_PORT=443; fi' >>/etc/bash.bashrc"
+    }
   },
   "postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 {
   "image": "quay.io/vgteam/vg:v1.49.0",
-  "forwardPorts": [3000],
+  "forwardPorts": [3001],
   "features": {
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": {"packages": "nano"},
     "ghcr.io/devcontainers-contrib/features/bash-command:1": {
-      "command": "echo aWYgW1sgISAteiAiJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSIgXV0gOyB0aGVuIGV4cG9ydCBXRFNfU09DS0VUX0hPU1Q9IiR7Q09ERVNQQUNFX05BTUV9LTMwMDAuJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSI7IGV4cG9ydCBXRFNfU09DS0VUX1BPUlQ9NDQzOyBmaQo= | base64 --decode >>/etc/bash.bashrc # Line to tell Webpack dev server to ignore HOST and use the Github Codespace port forward if we are in a Codespace. Need to base64 here because double quotes cannot be escaped through the devcontainer build process."
+      "command": "echo aWYgW1sgISAteiAiJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSIgXV0gOyB0aGVuIGV4cG9ydCBXRFNfU09DS0VUX0hPU1Q9IiR7Q09ERVNQQUNFX05BTUV9LTMwMDEuJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSI7IGV4cG9ydCBXRFNfU09DS0VUX1BPUlQ9NDQzOyBmaQo= | base64 --decode >>/etc/bash.bashrc # Line to tell Webpack dev server to ignore HOST and use the Github Codespace port forward if we are in a Codespace. Need to base64 here because double quotes cannot be escaped through the devcontainer build process."
     }
   },
   "postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "image": "quay.io/vgteam/vg:v1.49.0",
-  "forwardPorts": [3001],
+  "forwardPorts": [3000, 3001],
   "features": {
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/git:1": {},
@@ -9,6 +9,16 @@
       "command": "echo aWYgW1sgISAteiAiJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSIgXV0gOyB0aGVuIGV4cG9ydCBXRFNfU09DS0VUX0hPU1Q9IiR7Q09ERVNQQUNFX05BTUV9LTMwMDEuJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSI7IGV4cG9ydCBXRFNfU09DS0VUX1BPUlQ9NDQzOyBleHBvcnQgSE9TVD0wLjAuMC4wOyBleHBvcnQgSFRUUFM9dHJ1ZTsgZmkK | base64 --decode >>/etc/bash.bashrc # Line to tell Webpack dev server to ignore HOST and use the Github Codespace port forward if we are in a Codespace. Need to base64 here because double quotes cannot be escaped through the devcontainer build process."
     }
   },
-  "postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install"
+"postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install",
+"portsAttributes": {
+	"3001": {
+		"label": "devserver",
+    "protocol": "https"
+	},
+  "3000": {
+    "label": "api",
+    "onAutoForward": "silent"
+  }
+}
 }
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers-contrib/features/bash-command:1": {
-      "command": "echo 'if [[ ! -z \"$GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN\" ]] ; then export WDS_SOCKET_HOST=\"${CODESPACE_NAME}-3000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; export WDS_SOCKET_PORT=443; fi' >>/etc/bash.bashrc"
+      "command": "echo aWYgW1sgISAteiAiJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSIgXV0gOyB0aGVuIGV4cG9ydCBXRFNfU09DS0VUX0hPU1Q9IiR7Q09ERVNQQUNFX05BTUV9LTMwMDAuJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSI7IGV4cG9ydCBXRFNfU09DS0VUX1BPUlQ9NDQzOyBmaQo= | base64 --decode >>/etc/bash.bashrc # Line to tell Webpack dev server to ignore HOST and use the Github Codespace port forward if we are in a Codespace. Need to base64 here because double quotes cannot be escaped through the devcontainer build process."
     }
   },
   "postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": {"packages": "nano"},
     "ghcr.io/devcontainers-contrib/features/bash-command:1": {
-      "command": "echo aWYgW1sgISAteiAiJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSIgXV0gOyB0aGVuIGV4cG9ydCBXRFNfU09DS0VUX0hPU1Q9IiR7Q09ERVNQQUNFX05BTUV9LTMwMDEuJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSI7IGV4cG9ydCBXRFNfU09DS0VUX1BPUlQ9NDQzOyBmaQo= | base64 --decode >>/etc/bash.bashrc # Line to tell Webpack dev server to ignore HOST and use the Github Codespace port forward if we are in a Codespace. Need to base64 here because double quotes cannot be escaped through the devcontainer build process."
+      "command": "echo aWYgW1sgISAteiAiJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSIgXV0gOyB0aGVuIGV4cG9ydCBXRFNfU09DS0VUX0hPU1Q9IiR7Q09ERVNQQUNFX05BTUV9LTMwMDEuJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSI7IGV4cG9ydCBXRFNfU09DS0VUX1BPUlQ9NDQzOyBleHBvcnQgSE9TVD0wLjAuMC4wOyBleHBvcnQgSFRUUFM9dHJ1ZTsgZmkK | base64 --decode >>/etc/bash.bashrc # Line to tell Webpack dev server to ignore HOST and use the Github Codespace port forward if we are in a Codespace. Need to base64 here because double quotes cannot be escaped through the devcontainer build process."
     }
   },
   "postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "quay.io/vgteam/vg:v1.49.0",
+  "forwardPorts": [3000, 3001],
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {}
+  },
+  "postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install"
+}
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers-contrib/features/apt-packages:1": {"packages": "nano"},
+    "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": {"packages": "nano"},
     "ghcr.io/devcontainers-contrib/features/bash-command:1": {
       "command": "echo aWYgW1sgISAteiAiJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSIgXV0gOyB0aGVuIGV4cG9ydCBXRFNfU09DS0VUX0hPU1Q9IiR7Q09ERVNQQUNFX05BTUV9LTMwMDAuJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSI7IGV4cG9ydCBXRFNfU09DS0VUX1BPUlQ9NDQzOyBmaQo= | base64 --decode >>/etc/bash.bashrc # Line to tell Webpack dev server to ignore HOST and use the Github Codespace port forward if we are in a Codespace. Need to base64 here because double quotes cannot be escaped through the devcontainer build process."
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "image": "quay.io/vgteam/vg:v1.49.0",
-  "forwardPorts": [3000, 3001],
+  "forwardPorts": [3000],
   "features": {
     "ghcr.io/devcontainers/features/node:1": {}
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
   "image": "quay.io/vgteam/vg:v1.49.0",
   "forwardPorts": [3000],
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {}
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/git:1": {}
   },
   "postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers-contrib/features/apt-packages:1": {"packages": "nano"},
     "ghcr.io/devcontainers-contrib/features/bash-command:1": {
       "command": "echo aWYgW1sgISAteiAiJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSIgXV0gOyB0aGVuIGV4cG9ydCBXRFNfU09DS0VUX0hPU1Q9IiR7Q09ERVNQQUNFX05BTUV9LTMwMDAuJHtHSVRIVUJfQ09ERVNQQUNFU19QT1JUX0ZPUldBUkRJTkdfRE9NQUlOfSI7IGV4cG9ydCBXRFNfU09DS0VUX1BPUlQ9NDQzOyBmaQo= | base64 --decode >>/etc/bash.bashrc # Line to tell Webpack dev server to ignore HOST and use the Github Codespace port forward if we are in a Codespace. Need to base64 here because double quotes cannot be escaped through the devcontainer build process."
     }

--- a/src/App.js
+++ b/src/App.js
@@ -43,6 +43,8 @@ class App extends Component {
   constructor(props) {
     super(props);
 
+    console.log('Tube map statting up with API URL: ' + props.apiUrl)
+
     // Set defaultViewTarget to either URL params (if present) or the first example
     this.defaultViewTarget =
       urlParamsToViewTarget(document.location) ?? config.DATA_SOURCES[0];
@@ -213,7 +215,7 @@ App.defaultProps = {
   // the config or the browser, but needs to be swapped out in the fake
   // browser testing environment to point to a real testing backend.
   // Note that host includes the port.
-  apiUrl: (config.BACKEND_URL || `http://${window.location.host}`) + "/api/v0",
+  apiUrl: (config.BACKEND_URL || `${window.location.origin}`) + "/api/v0",
 };
 
 export default App;


### PR DESCRIPTION
This sets up a devcontainer configuration so that the tube map can work in [Github Codespaces](https://github.com/features/codespaces). This will let people develop on the tube map using a potato, provided the potato can run a web browser and log in to Github. Codespaces also integrate with a local VS Code editor.

It includes some base64-encoded Bash glue to set the right environment variables to make the Webpack dev server, as configured by Create React App, happy behind the proxy domains that Github creates to achieve a "port forward" into a container with Github login access control in front of it. I couldn't figure out how to get the glue through the container build process without encoding it, except for maybe making a separate Dockerfile for the devcontainer.