### PR TITLE
Split multiple GAM tracks vertically

### DIFF
--- a/src/components/CopyLink.js
+++ b/src/components/CopyLink.js
@@ -79,6 +79,6 @@ export const urlParamsToViewTarget = (url) => {
   if (s[1]) {
     result = qs.parse(s[1]);
   }
- 
+
   return result;
 };

--- a/src/components/CopyLink.js
+++ b/src/components/CopyLink.js
@@ -80,5 +80,9 @@ export const urlParamsToViewTarget = (url) => {
     result = qs.parse(s[1]);
   }
 
+  // TODO: qs can't tell the difference between false and "false", and "false"
+  // is truthy. So we need to go through and coerce things to real booleans at
+  // some point.
+
   return result;
 };

--- a/src/components/HeaderForm.js
+++ b/src/components/HeaderForm.js
@@ -67,6 +67,9 @@ const EMPTY_STATE = {
   // These ones are for selecting entire files and need to be preserved when
   // switching dataType.
   fileSelectOptions: [],
+  // This one is for the BED files. It needs to exist when we start up or we
+  // will try and draw the BED dropdown without an array of options.
+  bedSelectOptions: []
 };
 
 // Creates track to be stored in ViewTarget

--- a/src/components/TubeMap.js
+++ b/src/components/TubeMap.js
@@ -41,12 +41,12 @@ class TubeMap extends Component {
     tubeMap.setShowReadsFlag(visOptions.showReads);
     tubeMap.setSoftClipsFlag(visOptions.showSoftClips);
 
-    for (let i = 0; i < visOptions.colorSchemes.length; i++) {
+    for (let key of Object.keys(visOptions.colorSchemes)) {
       // Apply color-by-mapping-quality parameter to all the schemes.
       // TODO: When we get individual controls, pass through individual track options.
-      let colorScheme = {...visOptions.colorSchemes[i], colorReadsByMappingQuality: visOptions.colorReadsByMappingQuality};
+      let colorScheme = {...visOptions.colorSchemes[key], colorReadsByMappingQuality: visOptions.colorReadsByMappingQuality};
       // update tubemap colors
-      tubeMap.setColorSet(i, colorScheme);
+      tubeMap.setColorSet(key, colorScheme);
     }
     tubeMap.setMappingQualityCutoff(visOptions.mappingQualityCutoff);
   }  

--- a/src/components/TubeMap.js
+++ b/src/components/TubeMap.js
@@ -41,13 +41,12 @@ class TubeMap extends Component {
     tubeMap.setShowReadsFlag(visOptions.showReads);
     tubeMap.setSoftClipsFlag(visOptions.showSoftClips);
 
-    // apply new colorReadsByMappingQuality value to all tracks
-    // to be changed, add options to change colorReadsByMappingQuality individually
-    tubeMap.setColorReadsByMappingQualityFlag(visOptions.colorReadsByMappingQuality);
-
     for (let i = 0; i < visOptions.colorSchemes.length; i++) {
+      // Apply color-by-mapping-quality parameter to all the schemes.
+      // TODO: When we get individual controls, pass through individual track options.
+      let colorScheme = {...visOptions.colorSchemes[i], colorReadsByMappingQuality: visOptions.colorReadsByMappingQuality};
       // update tubemap colors
-      tubeMap.setColorSet(i, visOptions.colorSchemes[i]);
+      tubeMap.setColorSet(i, colorScheme);
     }
     tubeMap.setMappingQualityCutoff(visOptions.mappingQualityCutoff);
   }  

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -151,7 +151,6 @@ const config = {
            // colors corresponds with tracks(input files), [haplotype, read1, read2, ...]
   exonColors: "lightColors",
   hideLegendFlag: false,
-  colorReadsByMappingQuality: false,
   mappingQualityCutoff: 0,
   // Should different source tracks be separated vertically?
   collateTracks: true,
@@ -367,7 +366,7 @@ export function setShowReadsFlag(value) {
 
 export function setColorSet(fileID, newColor) {
   const currColor = config.colorSchemes[fileID];
-  // update if forward or backward color is different
+  // update if any coloring parameter is different
   if (!currColor || !deepEqual(currColor, newColor)) {
     config.colorSchemes[fileID] = newColor;
     const tr = createTubeMap();
@@ -392,19 +391,6 @@ export function setNodeWidthOption(value) {
 // accept a string argument to be displayed.
 export function setInfoCallback(newCallback) {
   config.showInfoCallback = newCallback;
-}
-
-export function setColorReadsByMappingQualityFlag(value) {
-  // TODO: add options to change colorReadsByMappingQuality individually
-  if (config.colorReadsByMappingQuality !== value) {
-    config.colorReadsByMappingQuality = value;
-    // update all values
-    for (let i = 0; i < config.colorSchemes.length; i++) {
-      config.colorSchemes[i].colorReadsByMappingQuality = value;
-    }
-    svg = d3.select(svgID);
-    createTubeMap();
-  }
 }
 
 export function setMappingQualityCutoff(value) {

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -587,6 +587,8 @@ function setMapToMax(map, key, value) {
   }
 }
 
+const READ_WIDTH = 7;
+
 // add info about reads to nodes (incoming, outgoing and internal reads)
 function assignReadsToNodes() {
   nodes.forEach((node) => {
@@ -595,7 +597,7 @@ function assignReadsToNodes() {
     node.internalReads = [];
   });
   reads.forEach((read, idx) => {
-    read.width = 7;
+    read.width = i7;
     if (read.path.length === 1) {
       nodes[read.path[0].node].internalReads.push(idx);
     } else {
@@ -647,7 +649,7 @@ function placeReads() {
         currentY,
         node
       );
-      currentY += 7;
+      currentY += READ_WIDTH;
     });
     let maxY = currentY;
 
@@ -666,7 +668,7 @@ function placeReads() {
         !occupiedUntil.has(currentY) ||
         occupiedUntil.get(currentY) + 1 < reads[readElement[0]].firstNodeOffset
       ) {
-        currentY += 7;
+        currentY += READ_WIDTH;
         maxY = Math.max(maxY, currentY);
       } else {
         // otherwise push down incoming reads to make place for outgoing Read
@@ -675,7 +677,7 @@ function placeReads() {
           const incRead = reads[incReadElementIndices[0]];
           const incReadPathElement = incRead.path[incReadElementIndices[1]];
           if (incReadPathElement.y >= currentY) {
-            incReadPathElement.y += 7;
+            incReadPathElement.y += READ_WIDTH;
             setOccupiedUntil(
               occupiedUntil,
               incRead,
@@ -685,8 +687,8 @@ function placeReads() {
             );
           }
         });
-        currentY += 7;
-        maxY += 7;
+        currentY += READ_WIDTH;
+        maxY += READ_WIDTH;
       }
     });
 
@@ -701,7 +703,7 @@ function placeReads() {
         currentRead.firstNodeOffset < occupiedUntil.get(currentY) + 2 ||
         currentRead.finalNodeCoverLength > occupiedFrom.get(currentY) - 3
       ) {
-        currentY += 7;
+        currentY += READ_WIDTH;
       }
       currentRead.path[0].y = currentY;
       occupiedUntil.set(currentY, currentRead.finalNodeCoverLength);
@@ -2841,6 +2843,8 @@ function createFeatureRectangle(
   return { xStart: rectXStart, highlight: currentHighlight };
 }
 
+const MIN_BEND_WIDTH = 7;
+
 function generateForwardToReverse(
   x,
   yStart,
@@ -2855,7 +2859,7 @@ function generateForwardToReverse(
   x += 10 * extraRight[order];
   const yTop = Math.min(yStart, yEnd);
   const yBottom = Math.max(yStart, yEnd);
-  const radius = 7;
+  const radius = MIN_BEND_WIDTH;
 
   trackVerticalRectangles.push({
     // elongate incoming rectangle a bit to the right
@@ -2872,7 +2876,7 @@ function generateForwardToReverse(
     // vertical rectangle
     xStart: x + 5 + radius,
     yStart: yTop + trackWidth + radius - 1,
-    xEnd: x + 5 + radius + Math.min(7, trackWidth) - 1,
+    xEnd: x + 5 + radius + Math.min(MIN_BEND_WIDTH, trackWidth) - 1,
     yEnd: yBottom - radius + 1,
     color: trackColor,
     id: trackID,
@@ -2892,16 +2896,16 @@ function generateForwardToReverse(
 
   let d = `M ${x + 5} ${yBottom}`;
   d += ` Q ${x + 5 + radius} ${yBottom} ${x + 5 + radius} ${yBottom - radius}`;
-  d += ` H ${x + 5 + radius + Math.min(7, trackWidth)}`;
-  d += ` Q ${x + 5 + radius + Math.min(7, trackWidth)} ${
+  d += ` H ${x + 5 + radius + Math.min(MIN_BEND_WIDTH, trackWidth)}`;
+  d += ` Q ${x + 5 + radius + Math.min(MIN_BEND_WIDTH, trackWidth)} ${
     yBottom + trackWidth
   } ${x + 5} ${yBottom + trackWidth}`;
   d += " Z ";
   trackCorners.push({ path: d, color: trackColor, id: trackID, type });
 
   d = `M ${x + 5} ${yTop}`;
-  d += ` Q ${x + 5 + radius + Math.min(7, trackWidth)} ${yTop} ${
-    x + 5 + radius + Math.min(7, trackWidth)
+  d += ` Q ${x + 5 + radius + Math.min(MIN_BEND_WIDTH, trackWidth)} ${yTop} ${
+    x + 5 + radius + Math.min(MIN_BEND_WIDTH, trackWidth)
   } ${yTop + trackWidth + radius}`;
   d += ` H ${x + 5 + radius}`;
   d += ` Q ${x + 5 + radius} ${yTop + trackWidth} ${x + 5} ${
@@ -2925,7 +2929,7 @@ function generateReverseToForward(
 ) {
   const yTop = Math.min(yStart, yEnd);
   const yBottom = Math.max(yStart, yEnd);
-  const radius = 7;
+  const radius = MIN_BEND_WIDTH;
   x -= 10 * extraLeft[order];
 
   trackVerticalRectangles.push({
@@ -2939,7 +2943,7 @@ function generateReverseToForward(
     type,
   }); // elongate incoming rectangle a bit to the left
   trackVerticalRectangles.push({
-    xStart: x - 5 - radius - Math.min(7, trackWidth),
+    xStart: x - 5 - radius - Math.min(MIN_BEND_WIDTH, trackWidth),
     yStart: yTop + trackWidth + radius - 1,
     xEnd: x - 5 - radius - 1,
     yEnd: yBottom - radius + 1,
@@ -2962,8 +2966,8 @@ function generateReverseToForward(
   // Path for bottom 90 degree bend
   let d = `M ${x - 5} ${yBottom}`;
   d += ` Q ${x - 5 - radius} ${yBottom} ${x - 5 - radius} ${yBottom - radius}`;
-  d += ` H ${x - 5 - radius - Math.min(7, trackWidth)}`;
-  d += ` Q ${x - 5 - radius - Math.min(7, trackWidth)} ${
+  d += ` H ${x - 5 - radius - Math.min(MIN_BEND_WIDTH, trackWidth)}`;
+  d += ` Q ${x - 5 - radius - Math.min(MIN_BEND_WIDTH, trackWidth)} ${
     yBottom + trackWidth
   } ${x - 5} ${yBottom + trackWidth}`;
   d += " Z ";
@@ -2971,8 +2975,8 @@ function generateReverseToForward(
 
   // Path for top 90 degree bend
   d = `M ${x - 5} ${yTop}`;
-  d += ` Q ${x - 5 - radius - Math.min(7, trackWidth)} ${yTop} ${
-    x - 5 - radius - Math.min(7, trackWidth)
+  d += ` Q ${x - 5 - radius - Math.min(MIN_BEND_WIDTH, trackWidth)} ${yTop} ${
+    x - 5 - radius - Math.min(MIN_BEND_WIDTH, trackWidth)
   } ${yTop + trackWidth + radius}`;
   d += ` H ${x - 5 - radius}`;
   d += ` Q ${x - 5 - radius} ${yTop + trackWidth} ${x - 5} ${
@@ -4240,7 +4244,7 @@ function drawMismatches() {
                 (mm.pos !== read.finalNodeCoverLength ||
                   i !== read.sequenceNew.length - 1))
             ) {
-              drawInsertion(x - 3, y + 7, mm.seq, node.y);
+              drawInsertion(x - 3, y + READ_WIDTH, mm.seq, node.y);
             }
           } else if (mm.type === "deletion") {
             const x2 = getXCoordinateOfBaseWithinNode(node, mm.pos + mm.length);
@@ -4250,7 +4254,7 @@ function drawMismatches() {
               node,
               mm.pos + mm.seq.length
             );
-            drawSubstitution(x + 1, x2, y + 7, node.y, mm.seq);
+            drawSubstitution(x + 1, x2, y + READ_WIDTH, node.y, mm.seq);
           }
         });
       });
@@ -4297,7 +4301,7 @@ function drawDeletion(x1, x2, y, nodeY) {
     .attr("y1", y - 1)
     .attr("x2", x2)
     .attr("y2", y - 1)
-    .attr("stroke-width", 7)
+    .attr("stroke-width", READ_WIDTH)
     .attr("stroke", "grey")
     .attr("nodeY", nodeY)
     .on("mouseover", deletionMouseOver)
@@ -4359,7 +4363,7 @@ function substitutionMouseOver() {
     .append("line")
     .attr("class", "substitutionHighlight")
     .attr("x1", x1 - 1)
-    .attr("y1", y - 7)
+    .attr("y1", y - READ_WIDTH)
     .attr("x2", x1 - 1)
     .attr("y2", yTop + 5)
     .attr("stroke-width", 1)
@@ -4368,7 +4372,7 @@ function substitutionMouseOver() {
     .append("line")
     .attr("class", "substitutionHighlight")
     .attr("x1", x2 + 1)
-    .attr("y1", y - 7)
+    .attr("y1", y - READ_WIDTH)
     .attr("x2", x2 + 1)
     .attr("y2", yTop + 5)
     .attr("stroke-width", 1)

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -130,6 +130,8 @@ const config = {
   hideLegendFlag: false,
   colorReadsByMappingQuality: false,
   mappingQualityCutoff: 0,
+  // Should different source tracks be separated vertically?
+  collateTracks: true,
   showInfoCallback: function(info) {alert(info)},
 };
 

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -632,16 +632,29 @@ function placeReads() {
   const sortedNodes = nodes.slice();
   sortedNodes.sort(compareNodesByOrder);
 
-  // Make a list of all read indexes
-  let allReadIDs = [];
+  // Organize read IDs by source track
+  let readsBySource = {};
   for (let i = 0; i < reads.length; i++) {
-    allReadIDs.push(i);
+    let source = reads[i].sourceTrackID;
+    if (readsBySource[source] === undefined) {
+      // First read from this source
+      readsBySource[source] = [i];
+    } else {
+      // Put it with the others from this source
+      readsBySource[source].push(i);
+    }
   }
 
-  // iterate over all nodes
-  sortedNodes.forEach((node) => {
-    placeReadSet(allReadIDs, node);
-  });
+  let allSources = Object.keys(readsBySource);
+  allSources.sort();
+  for (let source of allSources) {
+    // Go through all source tracks in order
+    console.log("Lay out read track", source);
+    sortedNodes.forEach((node) => {
+      // And for each node, place these reads in it.
+      placeReadSet(readsBySource[source], node);
+    });
+  }
 
   // place read segments which are without node
   const bottomY = calculateBottomY();

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -633,7 +633,6 @@ function placeReads() {
   allSources.sort();
   for (let source of allSources) {
     // Go through all source tracks in order
-    console.log("Lay out read track", source);
     sortedNodes.forEach((node) => {
       // And for each node, place these reads in it.
       // Use a margin to separate multiple read tracks if we have them.
@@ -691,8 +690,6 @@ function placeReadSet(readIDs, node, topMargin) {
   if (incomingReads.length === 0 && outgoingReads.length === 0 && internalReads.length === 0) {
     topMargin = 0;
   }
-
-  console.log("Top margin node " + node.name + ": ", topMargin);
 
   // Determine where we start vertically in the node. 
   let startY = node.y + node.contentHeight + topMargin;

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -2296,18 +2296,21 @@ function calculateTrackWidth() {
   // flag: if vg returns freq of 0 for all tracks, we will increase width manually
   let allAreFour = true;
 
+  const NARROW_WIDTH = 4;
+  const WIDE_WIDTH = 15;
+
   tracks.forEach((track) => {
     if (track.hasOwnProperty("freq")) {
       // custom track width
-      track.width = Math.round((Math.log(track.freq) + 1) * 4);
+      track.width = Math.round((Math.log(track.freq) + 1) * NARROW_WIDTH);
     } else {
       // default track width
-      track.width = 15;
+      track.width = WIDE_WIDTH;
       if (track.hasOwnProperty("type") && track.type === "read") {
-        track.width = 4;
+        track.width = NARROW_WIDTH;
       }
     }
-    if (track.width !== 4) {
+    if (track.width !== NARROW_WIDTH) {
       allAreFour = false;
     }
   });
@@ -2315,7 +2318,7 @@ function calculateTrackWidth() {
   if (allAreFour) {
     tracks.forEach((track) => {
       if (track.hasOwnProperty("freq")) {
-        track.width = 15;
+        track.width = WIDE_WIDTH;
       }
     });
   }


### PR DESCRIPTION
This changes GAM layout so that multiple tracks are laid out separately in separate passes, one below the other.

It looks like this, where I have an orange GAM and then a purple GAM. There's a 1-read-high margin between/above GAM tracks in each node when multiple GAM tracks are added.

![graph(1)](https://github.com/vgteam/sequenceTubeMap/assets/5062495/83d43292-92bc-4e73-adfa-d7b063c7c3b3)

This PR also includes some fixes for deserializing the link to view URLs and for tunring mapping quality coloring on and off, since I ran into related bugs when trying to use the view links to test this.

This will fix #216.