### PR TITLE
Parse vg chunk GAM names and send back as an ordered array

### DIFF
--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -174,8 +174,8 @@ class TubeMapContainer extends Component {
         let readsArr = [];
         // Count total reads seen so far.
         let totalReads = 0;
-        console.log("json gams", Object.values(json.gam));
-        for (const gam of Object.values(json.gam)) {
+        console.log("json gams", json.gam);
+        for (const gam of json.gam) {
           // For each returned list of reads from a file, convert all those reads to tube map format.
           // Include total read count to prevent duplicate ids.
           // Also include the source track's ID.

--- a/src/end-to-end.test.js
+++ b/src/end-to-end.test.js
@@ -298,7 +298,7 @@ describe("When we wait for it to load", () => {
     // See if correct svg rendered
     let svg = document.getElementById("svg");
     expect(svg).toBeTruthy();
-    expect(svg.getElementsByTagName("title").length).toEqual(20);
+    expect(svg.getElementsByTagName("title").length).toEqual(23);
   });
 
 });


### PR DESCRIPTION
This will fix #312 by ordering the GAMs based on the naming convention used by vg chunk [here](https://github.com/vgteam/vg/blob/855294e5e0178b96e22753fc6ce2ae71e37a5726/src/subcommand/chunk_main.cpp#L937).

We are also now sending GAMs back as an array instead of an object, because the keys we were using were internal temp file names and not the real GAM track names anyway.