### PR TITLE
Better scrolling and panning for tall graphs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,13 +42,15 @@ input[type="file"] {
 
 /* the div containing the tubemap svg */
 #tubeMapSVG {
-  overflow: auto;
-  width: calc(100% - 40px);
   position: relative;
   margin: 20px;
   border: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 0.25rem;
-  max-height: 75vh;
+}
+
+#svg {
+  width: 100%;
+  height: 75vh;
 }
 
 /* contains the spinning loader */

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -175,12 +175,10 @@ class TubeMapContainer extends Component {
         let readsArr = [];
         // Count total reads seen so far.
         let totalReads = 0;
-        console.log("json gams", json.gam);
         for (const gam of json.gam) {
           // For each returned list of reads from a file, convert all those reads to tube map format.
           // Include total read count to prevent duplicate ids.
           // Also include the source track's ID.
-          console.log("readTrackIDs", readTrackIDs);
           let newReads = tubeMap.vgExtractReads(nodes, tracks, gam, totalReads, readTrackIDs[readsArr.length]);
           readsArr.push(newReads);
           totalReads += newReads.length;

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -1188,6 +1188,13 @@ function getImageDimensions() {
   });
 }
 
+// This needs to be the width of the ruler.
+// TODO: Tell the ruler drawing code.
+const RULER_WIDTH = 15;
+const NODE_MARGIN = 10;
+// This is how much space to let us pan, around the nodes as measure by getImageDimensions()
+const RAIL_SPACE = 25;
+
 // align visualization to the top and left within svg and resize svg to correct size
 // enable zooming and panning
 function alignSVG() {
@@ -1197,28 +1204,17 @@ function alignSVG() {
   // And find its parent holding element.
   let parentElement = svgElement.parentNode;
 
-  svg.attr("height", maxYCoordinate - minYCoordinate + 50);
-  svg.attr("width", parentElement.offsetWidth);
+  svg.attr("height", maxYCoordinate - minYCoordinate + RAIL_SPACE * 2);
+  svg.attr("width", parentElement.clientWidth);
 
   function zoomed() {
     const transform = d3.event.transform;
-    // vertical adjustment so that top of graph is at top of svg
-    // otherwise would violate translateExtent, which leads to graph "jumping" on next pan
-    transform.y = (25 - minYCoordinate) * transform.k;
     svg.attr("transform", transform);
-    const svg2 = d3.select(svgID);
-    // adjust height, so that vertical scroll bar is shown when necessary
-    svg2.attr(
-      "height",
-      (maxYCoordinate - minYCoordinate + 50) * d3.event.transform.k
-    );
-    // adjust width to compensate for verical scroll bar appearing
-    svg2.attr("width", document.getElementById("tubeMapSVG").clientWidth);
   }
 
   const minZoom = Math.min(
     1,
-    parentElement.offsetWidth / (maxXCoordinate + 10)
+    parentElement.clientWidth / (maxXCoordinate + 10)
   );
   zoom = d3
     .zoom()
@@ -1226,19 +1222,19 @@ function alignSVG() {
     // to zoom breaks on the React testing jsdom
     .extent([
       [0, 0],
-      [svg.attr("width"), svg.attr("height")],
+      [parentElement.clientWidth, parentElement.clientHeight],
     ])
     .scaleExtent([minZoom, 8])
     .translateExtent([
-      [-1, minYCoordinate - 25],
-      [maxXCoordinate + 2, maxYCoordinate + 25],
+      [0, minYCoordinate - RAIL_SPACE],
+      [maxXCoordinate, maxYCoordinate + RAIL_SPACE],
     ])
     .on("zoom", zoomed);
 
   svg = svg.call(zoom).on("dblclick.zoom", null).append("g");
 
   // translate to correct position on initial draw
-  const containerWidth = parentElement.offsetWidth;
+  const containerWidth = parentElement.clientWidth;
   const xOffset =
     maxXCoordinate + 10 < containerWidth
       ? (containerWidth - maxXCoordinate - 10) / 2
@@ -1247,7 +1243,7 @@ function alignSVG() {
     .select(svgID)
     .call(
       zoom.transform,
-      d3.zoomIdentity.translate(xOffset, 25 - minYCoordinate)
+      d3.zoomIdentity.translate(xOffset, RAIL_SPACE - minYCoordinate)
     );
 }
 
@@ -1260,7 +1256,7 @@ export function zoomBy(zoomFactor) {
 
   const minZoom = Math.min(
     1,
-    parentElement.offsetWidth / (maxXCoordinate + 10)
+    parentElement.clientWidth / (maxXCoordinate + 10)
   );
   const maxZoom = 8;
   const width = parentElement.clientWidth;

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -1248,11 +1248,13 @@ function alignSVG() {
   parentElement.addEventListener("wheel", (e) => { e.preventDefault(); })
 
   // If the view area resizes, reconfigure the zoom
-  const resizeObserver = new ResizeObserver((resizes) => {
-    configureZoomBounds();
-  });
-  resizeObserver.observe(parentElement);
-
+  if (window.ResizeObserver) {
+    // This feature is in all current major browsers, but not in React's testing environment.
+    const resizeObserver = new window.ResizeObserver((resizes) => {
+      configureZoomBounds();
+    });
+    resizeObserver.observe(parentElement);
+  }
 
   // translate to correct position on initial draw
   const containerWidth = parentElement.clientWidth;
@@ -2509,7 +2511,6 @@ function generateTrackColor(track, highlight) {
       trackColor = colorSet[track.id % colorSet.length];
     }
   }
-  console.log("trackColor:", trackColor)
   return trackColor;
 }
 

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -1241,7 +1241,11 @@ function alignSVG() {
 
   // Initially configure panning and zooming
   configureZoomBounds();
-  svg = svg.call(zoom).on("dblclick.zoom", null).append("g");
+  svg = svg.call(zoom)
+    .on("dblclick.zoom", null)
+    .append("g");
+  // Don't let scrolling bubble up from the visualization
+  parentElement.addEventListener("wheel", (e) => { e.preventDefault(); })
 
   // If the view area resizes, reconfigure the zoom
   const resizeObserver = new ResizeObserver((resizes) => {


### PR DESCRIPTION
This will fix #320. Now scrolling on the visualization can't scroll the page but only zooms the visualization. Also, we can pan both vertically and horizontally (again?). And the visualization stays full height even if you zoom out and the picture itself is smaller, preventing zooming from reflowing the whole page.