### PR TITLE
Fix track JSON load, make sure chunk ref path is first, and add script to help make a chunk from a graph

### DIFF
--- a/docker/config.json
+++ b/docker/config.json
@@ -51,14 +51,14 @@
   "internalDataPath": "./exampleData/internal",
 
   "defaultHaplotypeColorPalette" : {
-    "mainPalette": "ygreys", 
-    "auxPalette": "ygreys", 
+    "mainPalette": "greys", 
+    "auxPalette": "greys", 
     "colorReadsByMappingQuality": false
   },
   
   "defaultReadColorPalette" : {
-    "mainPalette": "reds", 
-    "auxPalette": "blues", 
+    "mainPalette": "blues", 
+    "auxPalette": "reds", 
     "colorReadsByMappingQuality": false
   },
 

--- a/exampleData/chunk-ref-1-20/tracks.json
+++ b/exampleData/chunk-ref-1-20/tracks.json
@@ -1,15 +1,15 @@
 {
     "trackFile": "cactus.vg", 
     "trackType": "graph", 
-    "trackColorSettings": {"mainPalette": "greys", "auxPalette": "ygreys"}
+    "trackColorSettings": {"mainPalette": "plainColors", "auxPalette": "greys"}
 },
 {
     "trackFile": "cactus0_10.sorted.gam", 
     "trackType": "read", 
-    "trackColorSettings": {"mainPalette": "greys", "auxPalette": "ygreys"}
+    "trackColorSettings": {"mainPalette": "blues", "auxPalette": "reds"}
 },
 {
     "trackFile": "cactus10_20.sorted.gam", 
     "trackType": "read", 
-    "trackColorSettings": {"mainPalette": "greys", "auxPalette": "ygreys"}
+    "trackColorSettings": {"mainPalette": "blues", "auxPalette": "reds"}
 }

--- a/scripts/prepare_local_chunk.sh
+++ b/scripts/prepare_local_chunk.sh
@@ -2,17 +2,16 @@
 set -e
 
 function usage() {
-    echo >&2 "${0}: Extract graph and read chunks for a region, producing a referencing line for a BED file on standard output"
+    echo >&2 "${0}: Prepare a tube map chunk and BED line on standard output from a pre-made subgraph. Only supports paths, not haplotypes."
     echo >&2
-    echo >&2 "Usage: ${0} -x mygraph.xg [-h mygraph.gbwt] -r chr1:1-100 [-d 'Description of region'] -o chunk-chr1-1-100 [-g mygam1.gam [-g mygam2.gam ...]] >> regions.bed"
+    echo >&2 "Usage: ${0} -x subgraph.xg -r chr1:1-100 [-d 'Description of region'] -o chunk-chr1-1-100 [-g mygam1.gam [-g mygam2.gam ...]] >> regions.bed"
     exit 1
 }
 
-while getopts x:h:g:r:o:d: flag
+while getopts x:g:r:o:d: flag
 do
     case "${flag}" in
         x) GRAPH_FILE=${OPTARG};;
-        h) HAPLOTYPE_FILE=${OPTARG};;
         g) GAM_FILES+=("$OPTARG");;
         r) REGION=${OPTARG};;
         o) OUTDIR=${OPTARG};;
@@ -53,33 +52,49 @@ if [[ -z "${DESC}" ]] ; then
 fi
 
 echo >&2 "Graph File: " $GRAPH_FILE
-echo >&2 "Haplotype File: " $HAPLOTYPE_FILE
 echo >&2 "Region: " $REGION
 echo >&2 "Output Directory: " $OUTDIR
 
 rm -fr $OUTDIR
 mkdir -p $OUTDIR
 
-vg_chunk_params=(-x $GRAPH_FILE -g -c 20 -p $REGION -T -b $OUTDIR/chunk -E $OUTDIR/regions.tsv)
+# Parse the region
+REGION_END="$(echo ${REGION} | rev | cut -f1 -d'-' | rev)"
+REGION_START="$(echo ${REGION} | rev | cut -f2 -d'-' | cut -f1 -d':' | rev)"
+REGION_CONTIG="$(echo ${REGION} | rev| cut -f2- -d':' | rev)"
 
 # construct track JSON for graph file
 jq -n --arg trackFile "${GRAPH_FILE}" --arg trackType "graph" --argjson trackColorSettings '{"mainPalette": "plainColors", "auxPalette": "greys"}' '$ARGS.named' >> $OUTDIR/tracks.json
 
-# construct track JSON for haplotype file, if provided
-if [[ ! -z "${HAPLOTYPE_FILE}" ]] ; then
-    jq -n --arg trackFile "${HAPLOTYPE_FILE}" --arg trackType "haplotype" --argjson trackColorSettings '{"mainPalette": "blues", "auxPalette": "reds"}' '$ARGS.named' >> $OUTDIR/tracks.json
-fi
+# Put the graphy file in place
+vg convert -p "${GRAPH_FILE}" > $OUTDIR/chunk.vg
+# Start the region BED inside the chunk
+printf "${REGION_CONTIG}\t${REGION_START}\t${REGION_END}" > $OUTDIR/regions.tsv
 
-# construct track JSON for each gam file
+
 echo >&2 "Gam Files:"
+GAM_NUM=0
 for GAM_FILE in "${GAM_FILES[@]}"; do
     echo >&2 " - $GAM_FILE"
+    # construct track JSON for each gam file
     jq -n --arg trackFile "${GAM_FILE}" --arg trackType "read" --argjson trackColorSettings '{"mainPalette": "blues", "auxPalette": "reds"}' '$ARGS.named' >> $OUTDIR/tracks.json
-    vg_chunk_params+=(-a $GAM_FILE)
+    # Work out a chunk-internal GAM name with the same leading numbering vg chunk uses
+    if [[ "${GAM_NUM}" == "0" ]] ; then
+        GAM_LEADER="chunk"
+    else
+        GAM_LEADER="chunk-${GAM_NUM}"
+    fi
+    GAM_CHUNK_NAME="${OUTDIR}/${GAM_LEADER}_0_${REGION_CONTIG}_${REGION_START}_${REGION_END}.gam"
+    # Put the chunk in place
+    cp "${GAM_FILE}" "${GAM_CHUNK_NAME}"
+    # List it in the regions TSV like vg would
+    printf "\t$(basename "${GAM_CHUNK_NAME}")" >> $OUTDIR/regions.tsv
+    GAM_NUM=$((GAM_NUM + 1))
 done
 
-# Call vg chunk
-vg chunk "${vg_chunk_params[@]}" > $OUTDIR/chunk.vg
+# Make the empty but required annotation file. We have no haplotypes to put in it.
+touch "${OUTDIR}/chunk_0_${REGION_CONTIG}_${REGION_START}_${REGION_END}.annotate.txt"
+printf "\tchunk_0_${REGION_CONTIG}_${REGION_START}_${REGION_END}.annotate.txt\n" >> $OUTDIR/regions.tsv
 
 for file in `ls $OUTDIR/`
 do
@@ -89,3 +104,4 @@ done
 # Print BED line
 cat $OUTDIR/regions.tsv | cut -f1-3 | tr -d "\n"
 printf "\t${DESC}\t${OUTDIR}\n"
+

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -30,7 +30,7 @@ class TubeMapContainer extends Component {
 
   handleFetchError(error, message) {
     if (!this.cancelSignal.aborted) {
-      console.log(message, error.name, error.message);
+      console.error(message, error);
       this.setState({ error: error, isLoading: false });
     } else {
       console.log("fetch canceled by componentWillUnmount", error.message);
@@ -199,7 +199,7 @@ class TubeMapContainer extends Component {
     } catch (error) {
       this.handleFetchError(
         error,
-        `POST to ${this.props.apiUrl}/getChunkedData failed:`
+        `Fetching and parsing POST to ${this.props.apiUrl}/getChunkedData failed:`
       );
     }
   };

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -26,6 +26,7 @@ const greys = [
   "#000000",
 ];
 
+// Greys but with a special color for the first thing.
 const ygreys = [
   "#9467bd",
   "#d9d9d9",
@@ -4229,6 +4230,12 @@ export function vgExtractReads(
 
   for (let i = 0; i < myReads.length; i += 1) {
     const read = myReads[i];
+
+    if (!read.path) {
+      // Read does not have a path assigned, this is an unmapped read.
+      continue;
+    }
+
     const sequence = [];
     const sequenceNew = [];
     let firstIndex = -1; // index within mapping of the first node id contained in nodeNames


### PR DESCRIPTION
This should fix the problem with #335 where we couldn't parse the track JSON.

It also adds a new script to try and make making a chunk from a pre-made subgraph easier, and it makes the chunk scripts output the BED lines you would want.