### PR TITLE
Make chunk scripts find config.json relative to themselves

### DIFF
--- a/scripts/prepare_chunks.sh
+++ b/scripts/prepare_chunks.sh
@@ -72,11 +72,11 @@ vg_chunk_params=(-x $GRAPH_FILE -g -c 20 -p $REGION -T -b $OUTDIR/chunk -E $OUTD
 # get path relative to directory above the scripts directory
 GRAPH_FILE_PATH=$(realpath --relative-to $(dirname ${BASH_SOURCE[0]})/../ $GRAPH_FILE)
 echo ${GRAPH_FILE_PATH}
-GRAPH_PALETTE="$(cat src/config.json | jq '.defaultGraphColorPalette')"
+GRAPH_PALETTE="$(cat " $(dirname ${BASH_SOURCE[0]})/../src/config.json" | jq '.defaultGraphColorPalette')"
 jq -n --arg trackFile "${GRAPH_FILE_PATH}" --arg trackType "graph" --argjson trackColorSettings "$GRAPH_PALETTE" '$ARGS.named' >> $OUTDIR/temp.json
 
 # construct track JSON for haplotype file, if provided
-HAPLOTYPE_PALETTE="$(cat src/config.json | jq '.defaultHaplotypeColorPalette')"
+HAPLOTYPE_PALETTE="$(cat "$(dirname ${BASH_SOURCE[0]})/../src/config.json" | jq '.defaultHaplotypeColorPalette')"
 if [[ ! -z "${HAPLOTYPE_FILE}" ]] ; then
     HAPLOTYPE_FILE_PATH=$(realpath --relative-to $(dirname ${BASH_SOURCE[0]})/../ $HAPLOTYPE_FILE)
     echo ${HAPLOTYPE_FILE_PATH}
@@ -85,7 +85,7 @@ fi
 
 # construct track JSON for each gam file
 echo >&2 "Gam Files:"
-READ_PALETTE="$(cat src/config.json | jq '.defaultReadColorPalette')"
+READ_PALETTE="$(cat "$(dirname ${BASH_SOURCE[0]})/../src/config.json" | jq '.defaultReadColorPalette')"
 echo >&2 "Read Palette: $READ_PALETTE"
 for GAM_FILE in "${GAM_FILES[@]}"; do
     GAM_FILE_PATH=$(realpath --relative-to $(dirname ${BASH_SOURCE[0]})/../ $GAM_FILE)

--- a/scripts/prepare_local_chunk.sh
+++ b/scripts/prepare_local_chunk.sh
@@ -71,7 +71,7 @@ REGION_CONTIG="$(echo ${REGION} | rev| cut -f2- -d':' | rev)"
 GRAPH_FILE_PATH=$(realpath --relative-to $(dirname ${BASH_SOURCE[0]})/../ $GRAPH_FILE)
 
 # construct track JSON for graph file
-GRAPH_PALETTE="$(cat src/config.json | jq '.defaultGraphColorPalette')"
+GRAPH_PALETTE="$(cat "$(dirname ${BASH_SOURCE[0]})/../src/config.json" | jq '.defaultGraphColorPalette')"
 jq -n --arg trackFile "${GRAPH_FILE_PATH}" --arg trackType "graph" --argjson trackColorSettings "$GRAPH_PALETTE" '$ARGS.named' >> $OUTDIR/temp.json
 
 # Put the graphy file in place
@@ -82,7 +82,7 @@ printf "${REGION_CONTIG}\t${REGION_START}\t${REGION_END}" > $OUTDIR/regions.tsv
 
 echo >&2 "Gam Files:"
 GAM_NUM=0
-READ_PALETTE="$(cat src/config.json | jq '.defaultReadColorPalette')"
+READ_PALETTE="$(cat "$(dirname ${BASH_SOURCE[0]})/../src/config.json" | jq '.defaultReadColorPalette')"
 for GAM_FILE in "${GAM_FILES[@]}"; do
     echo >&2 " - $GAM_FILE"
 


### PR DESCRIPTION
This should let us once again run the chunk preparation scripts even when we aren't standing in the root of the repository.