### PR TITLE
Lazy Bed Regions Download

### DIFF
--- a/exampleData/cactus_mixed_chunks.bed
+++ b/exampleData/cactus_mixed_chunks.bed
@@ -1,0 +1,3 @@
+ref	1	10	region one to ten	chunk-ref-1-20
+ref	10	20	region ten to twenty	chunk-ref-1-20
+ref	2000	3000	region two to three thousand	chunk-ref-2000-3000

--- a/src/common.mjs
+++ b/src/common.mjs
@@ -110,3 +110,19 @@ export function defaultTrackColors(trackType){
     throw new Error("Invalid track type: " + trackType); 
   }
 }
+
+// Excepts a string, returns whether or not the input is a valid http URL we can call fetch on
+export function isValidURL(string) {
+  if (!string) {
+    return false;
+  }
+
+  let url;
+  try {
+    url = new URL(string)
+  } catch(error) {
+    return false;
+  }
+
+  return url.protocol === "http:" || url.protocol === "https:";
+}

--- a/src/common.mjs
+++ b/src/common.mjs
@@ -111,7 +111,7 @@ export function defaultTrackColors(trackType){
   }
 }
 
-// Excepts a string, returns whether or not the input is a valid http URL we can call fetch on
+// Accepts a string, returns whether or not the input is a valid http URL we can call fetch on
 export function isValidURL(string) {
   if (!string) {
     return false;

--- a/src/common.mjs
+++ b/src/common.mjs
@@ -126,3 +126,7 @@ export function isValidURL(string) {
 
   return url.protocol === "http:" || url.protocol === "https:";
 }
+
+export function isEmpty(obj) {
+  return Object.keys(obj).length === 0;
+}

--- a/src/components/HeaderForm.js
+++ b/src/components/HeaderForm.js
@@ -533,7 +533,7 @@ class HeaderForm extends Component {
     if (tracks) {
       this.setState({ tracks: tracks });
       console.log("New tracks have been applied");
-    } else {
+    } else if (this.state.bedFile && chunk) {
       // Try to retrieve tracks from the server
       const json = await fetchAndParse(`${this.props.apiUrl}/getChunkTracks`, {
         method: "POST",

--- a/src/components/RegionInput.js
+++ b/src/components/RegionInput.js
@@ -3,10 +3,10 @@ import PropTypes from "prop-types";
 import TextField from "@mui/material/TextField";
 import Autocomplete from "@mui/material/Autocomplete";
 import FormHelperText from "@mui/material/FormHelperText";
+import { isEmpty } from "../common.mjs";
 
 // RegionInput: The path and region input box component
 // Responsible for selecting the path/chr and segment of data to look at
-const isEmpty = (obj) => Object.keys(obj).length === 0;
 
 export const RegionInput = ({
   region,
@@ -20,10 +20,6 @@ export const RegionInput = ({
   const pathNamesColon = pathNames.map((name) => name + ":");
   const pathsWithRegion = [];
 
-  // Store possible options from bed file and match them with their respective tracks
-  let optionToTrack = {};
-  let optionToChunk = {};
-
   if (regionInfo && !isEmpty(regionInfo)) {
     // Stitch path name + region start and end
     for (const [index, path] of regionInfo["chr"].entries()) {
@@ -32,17 +28,9 @@ export const RegionInput = ({
       );
     }
 
-    // populate optionToTrack and optionToChunk with paths with region
-    pathsWithRegion.forEach((path, i) => optionToTrack[path] = regionInfo.tracks[i]);
-    pathsWithRegion.forEach((path, i) => optionToChunk[path] = regionInfo.chunk[i]);
-
-
     // Add descriptions
     pathsWithRegion.push(...regionInfo["desc"]);
 
-    // populate optionToTrack and optionToChunk with paths with description as keys
-    regionInfo.desc.forEach((desc, i) => optionToTrack[desc] = regionInfo.tracks[i]);
-    regionInfo.desc.forEach((desc, i) => optionToChunk[desc] = regionInfo.chunk[i]);
   }
 
   // Autocomplete selectable options
@@ -60,15 +48,7 @@ export const RegionInput = ({
         id="regionInput"    
 
         onInputChange={(event, newInputValue) => {
-          // If an option is selected, should have a match in optionToTrack and optionToChunk
-          if (event.target.textContent in optionToTrack && event.target.textContent in optionToChunk) {
-            // pass tracks and chunk associated with the option
-            // handleRegionChange will determine if and how tracks are going to be updated
-            handleRegionChange(newInputValue, optionToTrack[event.target.textContent], optionToChunk[event.target.textContent]);
-          } else {
-            // only pass a region value, tracks will not be updated
-            handleRegionChange(newInputValue, null, null);
-          }
+          handleRegionChange(newInputValue);
         }}
 
         options={displayRegions}

--- a/src/components/RegionInput.js
+++ b/src/components/RegionInput.js
@@ -22,6 +22,7 @@ export const RegionInput = ({
 
   // Store possible options from bed file and match them with their respective tracks
   let optionToTrack = {};
+  let optionToChunk = {};
 
   if (regionInfo && !isEmpty(regionInfo)) {
     // Stitch path name + region start and end
@@ -31,14 +32,17 @@ export const RegionInput = ({
       );
     }
 
-    // populate optionToTrack with paths with region
+    // populate optionToTrack and optionToChunk with paths with region
     pathsWithRegion.forEach((path, i) => optionToTrack[path] = regionInfo.tracks[i]);
+    pathsWithRegion.forEach((path, i) => optionToChunk[path] = regionInfo.chunk[i]);
+
 
     // Add descriptions
     pathsWithRegion.push(...regionInfo["desc"]);
 
-    // populate optionToTrack with paths with description as keys
+    // populate optionToTrack and optionToChunk with paths with description as keys
     regionInfo.desc.forEach((desc, i) => optionToTrack[desc] = regionInfo.tracks[i]);
+    regionInfo.desc.forEach((desc, i) => optionToChunk[desc] = regionInfo.chunk[i]);
   }
 
   // Autocomplete selectable options
@@ -56,12 +60,14 @@ export const RegionInput = ({
         id="regionInput"    
 
         onInputChange={(event, newInputValue) => {
-          // If an option is selected, should have a match in optionToTrack
-          if (event.target.textContent in optionToTrack) {
-            // also pass tracks associated with the option
-            handleRegionChange(newInputValue, optionToTrack[event.target.textContent]);
+          // If an option is selected, should have a match in optionToTrack and optionToChunk
+          if (event.target.textContent in optionToTrack && event.target.textContent in optionToChunk) {
+            // pass tracks and chunk associated with the option
+            // handleRegionChange will determine if and how tracks are going to be updated
+            handleRegionChange(newInputValue, optionToTrack[event.target.textContent], optionToChunk[event.target.textContent]);
           } else {
-            handleRegionChange(newInputValue, null);
+            // only pass a region value, tracks will not be updated
+            handleRegionChange(newInputValue, null, null);
           }
         }}
 

--- a/src/components/RegionInput.js
+++ b/src/components/RegionInput.js
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import TextField from "@mui/material/TextField";
 import Autocomplete from "@mui/material/Autocomplete";
 import FormHelperText from "@mui/material/FormHelperText";
+import "../config-client.js";
+import "../config-global.mjs";
 import { isEmpty } from "../common.mjs";
 
 // RegionInput: The path and region input box component

--- a/src/components/RegionInput.test.js
+++ b/src/components/RegionInput.test.js
@@ -60,5 +60,5 @@ test("it calls handleRegionChange when region is changed with new region", async
   await userEvent.clear(input);
   await userEvent.type(input, NEW_REGION);
 
-  expect(handleRegionChangeMock).toHaveBeenLastCalledWith(NEW_REGION, null);
+  expect(handleRegionChangeMock).toHaveBeenLastCalledWith(NEW_REGION, null, null);
 });

--- a/src/components/RegionInput.test.js
+++ b/src/components/RegionInput.test.js
@@ -60,5 +60,5 @@ test("it calls handleRegionChange when region is changed with new region", async
   await userEvent.clear(input);
   await userEvent.type(input, NEW_REGION);
 
-  expect(handleRegionChangeMock).toHaveBeenLastCalledWith(NEW_REGION, null, null);
+  expect(handleRegionChangeMock).toHaveBeenLastCalledWith(NEW_REGION);
 });

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -277,7 +277,7 @@ async function getChunkedData(req, res, next) {
   // There's a chance this request was sent before the proper tracks were fetched
   // This can happen when the bed file is a url and track names need to be downloaded
   // Check if there are tracks specified by the bedFile
-  if (req.body.bedFile) {
+  if (req.body.bedFile && req.body.bedFile !== "none") {
     const chunk = await getChunkName(req.body.bedFile, parsedRegion);
     const fetchedTracks = await getChunkTracks(req.body.bedFile, chunk);
 
@@ -1418,7 +1418,7 @@ async function getChunkTracks (bedFile, chunk) {
 api.post("/getChunkTracks", (req, res, next) => {
   console.log("received request for chunk tracks");
   if (!req.body.bedFile || !req.body.chunk) {
-    throw new BadReqeustError("Invalid request format", req.body.bedFile, req.body.chunk);
+    throw new BadRequestError("Invalid request format", req.body.bedFile, req.body.chunk);
   }
   let promise = (async () => {
     // tracks are falsy if fetch is unsuccessful

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -283,8 +283,30 @@ async function getChunkedData(req, res, next) {
 
     // We're always replacing the given tracks if we were able to find tracks from the bed file
     if (fetchedTracks) {
-      console.log("Using new fetched tracks", JSON.stringify(req.body.tracks));
-      req.body.tracks = fetchedTracks;
+      // Color Settings are retained from the initial request
+      // if newly fetched tracks have matching file names
+      // Store current colors and file names
+      const fileToColor = new Map();
+      for (const key of Object.keys(req.body.tracks)) {
+        const track = req.body.tracks[key];
+        fileToColor.set(track["trackFile"], track["trackColorSettings"]);
+      }
+
+      // Replace new track colors if there's a matching file name
+      for (const track of fetchedTracks) {
+        if (fileToColor.has(track["trackFile"])) {
+          track["trackColorSettings"] = fileToColor.get(track["trackFile"]);
+        }
+      }
+
+      // Convert fetchedTracks into an object format the server expects
+      let fetchedTracksObject = fetchedTracks.reduce((accumulator, obj, index) => {
+        accumulator[index] = obj;
+        return accumulator;
+      }, {});
+
+      console.log("Using new fetched tracks", JSON.stringify(fetchedTracksObject));
+      req.body.tracks = fetchedTracksObject;
     }
   }
 


### PR DESCRIPTION
- Chunk metadata from the internet is no longer downloaded until region selection
- GetChunkedData now confirms tracks from a bedURL as user might've pressed Go before tracks are fetched
- Closes #353 

Summary of the current process for bedURLs:
- Upon receiving a bedURL, only the bed file is fetched and bedinfo such as regions are returned 
- Upon selection of a bed region, the respective tracks.json file for that chunk is fetched and tracks are loaded into the track picker if applicable
- Upon receiving a request to getChunkedData, if a bedURL is present, the tracks.json file is re-fetched(if necessary) and used instead of the given tracks from the request in case the user hit the GO button before tracks were loaded into the track picker
- getChunkedPath is called when a bed file is included in the request, downloading the remaining chunk if the bed is a URL and returning a chunk path pointing to the location of the download