### PR TITLE
Issues/364 prevent reads shuffle

### DIFF
--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -678,7 +678,7 @@ function placeReads() {
         // use previous y value from last segment with node instead 
         let previousValidY = null;
         let lastIndex = pathIdx - 1;
-        while (!previousValidY && lastIndex >= 0) {
+        while (previousValidY === null && lastIndex >= 0) {
           previousValidY = reads[idx].path[lastIndex].y;
           lastIndex = lastIndex - 1;
         }

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -688,8 +688,8 @@ function placeReads() {
       }
     });
   });
-  
-  console.log("elementsWithoutNode", elementsWithoutNode);
+
+  elementsWithoutNode.sort(compareNoNodeReadsByPreviousY);
   elementsWithoutNode.forEach((element) => {
     const segment = reads[element.readIndex].path[element.pathIndex];
     segment.y = bottomY[segment.order];

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -674,15 +674,22 @@ function placeReads() {
   reads.forEach((read, idx) => {
     read.path.forEach((element, pathIdx) => {
       if (!element.hasOwnProperty("y")) {
+        let previousValidY = null;
+        let lastIndex = pathIdx - 1;
+        while (!previousValidY && lastIndex >= 0) {
+          previousValidY = reads[idx].path[lastIndex].y;
+          lastIndex = lastIndex - 1;
+        }
         elementsWithoutNode.push({
           readIndex: idx,
           pathIndex: pathIdx,
-          previousY: reads[idx].path[pathIdx - 1].y,
+          previousY: previousValidY,
         });
       }
     });
   });
-  elementsWithoutNode.sort(compareNoNodeReadsByPreviousY);
+  
+  console.log("elementsWithoutNode", elementsWithoutNode);
   elementsWithoutNode.forEach((element) => {
     const segment = reads[element.readIndex].path[element.pathIndex];
     segment.y = bottomY[segment.order];

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -674,6 +674,8 @@ function placeReads() {
   reads.forEach((read, idx) => {
     read.path.forEach((element, pathIdx) => {
       if (!element.hasOwnProperty("y")) {
+        // previous y value from pathIdx - 1 might not exist yet if that segment is also without node 
+        // use previous y value from last segment with node instead 
         let previousValidY = null;
         let lastIndex = pathIdx - 1;
         while (!previousValidY && lastIndex >= 0) {


### PR DESCRIPTION
Reads outside of nodes are sorted by order, then a previous y value. However, consecutive reads outside of nodes have their y values computed simultaneously, resulting in the previous y value still being null. This resulted in consecutive read segments outside of nodes that have the same order value being randomly sorted.

Fix: Go back through the path and find the last computed y value(from the last visited node), and use that to sort segments.

Closes #364 

`chr6:82003584-82004084`

![Capture](https://github.com/vgteam/sequenceTubeMap/assets/23585956/047efa0b-65a4-4a11-bc98-f4ba1cd93f96)
