### PR TITLE
Improve Read Cycle Layout

### DIFF
--- a/src/components/ExampleSelectButtons.js
+++ b/src/components/ExampleSelectButtons.js
@@ -87,7 +87,16 @@ class ExampleSelectButtons extends Component {
             this.handleClick(dataOriginTypes.EXAMPLE_8, "plainColors")
           }
         >
-          Multiple Nodes Cycle
+          Multiple Nodes Cycle 1
+        </Button>
+        <Button
+          color="primary"
+          id="example9"
+          onClick={() =>
+            this.handleClick(dataOriginTypes.EXAMPLE_9, "plainColors")
+          }
+        >
+          Multiple Nodes Cycle 2
         </Button>
       </Form>
     );

--- a/src/components/ExampleSelectButtons.js
+++ b/src/components/ExampleSelectButtons.js
@@ -80,6 +80,15 @@ class ExampleSelectButtons extends Component {
         >
           Alignments to Reverse Nodes
         </Button>
+        <Button
+          color="primary"
+          id="example8"
+          onClick={() =>
+            this.handleClick(dataOriginTypes.EXAMPLE_8, "plainColors")
+          }
+        >
+          Multiple Nodes Cycle
+        </Button>
       </Form>
     );
   }

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -272,7 +272,6 @@ class TubeMapContainer extends Component {
           0,
           1 // Examples always have reads as track 1
         );
-        console.log("READS", reads);
         break;
       case dataOriginTypes.EXAMPLE_8:
         vg = data.cycleGraph;
@@ -285,8 +284,20 @@ class TubeMapContainer extends Component {
           0,
           1 // Examples always have reads as track 1
         );
-        
-        console.log("READS", reads);
+
+        break;
+      case dataOriginTypes.EXAMPLE_9:
+        vg = data.cycle2Graph;
+        nodes = tubeMap.vgExtractNodes(vg);
+        tracks = tubeMap.vgExtractTracks(vg, 0, 0); // Examples have paths and haplotypes as track 0.
+        reads = tubeMap.vgExtractReads(
+          nodes,
+          tracks,
+          data.cycle2Reads,
+          0,
+          1 // Examples always have reads as track 1
+        );
+
         break;
       case dataOriginTypes.NO_DATA:
         // Leave the data empty.

--- a/src/components/TubeMapContainer.js
+++ b/src/components/TubeMapContainer.js
@@ -272,6 +272,21 @@ class TubeMapContainer extends Component {
           0,
           1 // Examples always have reads as track 1
         );
+        console.log("READS", reads);
+        break;
+      case dataOriginTypes.EXAMPLE_8:
+        vg = data.cycleGraph;
+        nodes = tubeMap.vgExtractNodes(vg);
+        tracks = tubeMap.vgExtractTracks(vg, 0, 0); // Examples have paths and haplotypes as track 0.
+        reads = tubeMap.vgExtractReads(
+          nodes,
+          tracks,
+          data.cycleReads,
+          0,
+          1 // Examples always have reads as track 1
+        );
+        
+        console.log("READS", reads);
         break;
       case dataOriginTypes.NO_DATA:
         // Leave the data empty.

--- a/src/enums.js
+++ b/src/enums.js
@@ -7,5 +7,6 @@ export const dataOriginTypes = {
   EXAMPLE_5: "example 5",
   EXAMPLE_6: "example 6",
   EXAMPLE_7: "example 7",
+  EXAMPLE_8: "example 8",
   NO_DATA: "no data",
 };

--- a/src/enums.js
+++ b/src/enums.js
@@ -8,5 +8,6 @@ export const dataOriginTypes = {
   EXAMPLE_6: "example 6",
   EXAMPLE_7: "example 7",
   EXAMPLE_8: "example 8",
+  EXAMPLE_9: "example 9",
   NO_DATA: "no data",
 };

--- a/src/util/demo-data.js
+++ b/src/util/demo-data.js
@@ -112,6 +112,499 @@ export const demoReads = `
 {"sequence": "GGTTCCCACTCCATAAGGTAGTTCAGCACCGCCGTGTCCCGGCCGGGTCGCGGGGAGCCCCGGTACATCGCAGTGGGCTACGTGGACGACACGCAGTTCGTGCGGTTCGACAGCGACGCGGCGACTCCGAGGATGTAGCCGCAGGCGCCGTGGTTGGAGCAGGAGGGACCGGAGTATTGGGACCGGAGCACACGGAACATCAGGCCCGCGCACAGACTGACAAGAGTGAACCTGCCCATGCCGCGCCGCTACTACCACCAGAGCTAGGCCGGTGAATGACCCCGGCCTGGGGCGAAGGTCACGACCCCTCCTCATCCCCCACGGACGCCCCGGGTCCCCCCCGCGAGTCTCCGGCTCC", "path": {"mapping": [{"position": {"node_id": "3"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 2}, {"position": {"node_id": "5"}, "edit": [{"from_length": 16, "to_length": 16}], "rank": 3}, {"position": {"node_id": "6"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 4}, {"position": {"node_id": "8"}, "edit": [{"from_length": 10, "to_length": 10}], "rank": 5}, {"position": {"node_id": "9"}, "edit": [{"from_length": 29, "to_length": 29}], "rank": 6}, {"position": {"node_id": "10"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 7}, {"position": {"node_id": "12"}, "edit": [{"from_length": 2, "to_length": 2}], "rank": 8}, {"position": {"node_id": "13"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 9}, {"position": {"node_id": "14"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 10}, {"position": {"node_id": "15"}, "edit": [{"from_length": 6, "to_length": 6}], "rank": 11}, {"position": {"node_id": "16"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 12}, {"position": {"node_id": "18"}, "edit": [{"from_length": 10, "to_length": 10}], "rank": 13}, {"position": {"node_id": "19"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 14}, {"position": {"node_id": "21"}, "edit": [{"from_length": 3, "to_length": 3}], "rank": 15}, {"position": {"node_id": "23"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 16}, {"position": {"node_id": "24"}, "edit": [{"from_length": 10, "to_length": 10}], "rank": 17}, {"position": {"node_id": "25"}, "edit": [{"from_length": 5, "to_length": 5}], "rank": 18}, {"position": {"node_id": "26"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 19}, {"position": {"node_id": "28"}, "edit": [{"from_length": 26, "to_length": 26}], "rank": 20}, {"position": {"node_id": "29"}, "edit": [{"from_length": 2, "to_length": 2}], "rank": 21}, {"position": {"node_id": "30"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 22}, {"position": {"node_id": "32"}, "edit": [{"from_length": 29, "to_length": 29}], "rank": 23}, {"position": {"node_id": "33"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 24}, {"position": {"node_id": "34"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 25}, {"position": {"node_id": "35"}, "edit": [{"from_length": 32, "to_length": 32}], "rank": 26}, {"position": {"node_id": "36"}, "edit": [{"from_length": 8, "to_length": 8}], "rank": 27}, {"position": {"node_id": "38"}, "edit": [{"from_length": 1, "to_length": 1}], "rank": 28}, {"position": {"node_id": "39"}, "edit": [{"from_length": 23, "to_length": 23}], "rank": 29}, {"position": {"node_id": "40"}, "edit": [{"from_length": 7, "to_length": 7}], "rank": 30}]}, "score": 358, "identity": 1.0}
 `;
 
+export const cycleGraph = {
+  edge: [
+    {
+      from: "60080783",
+      from_start: true,
+      to: "60080786",
+      to_end: true,
+    },
+    {
+      from: "60080783",
+      from_start: true,
+      to: "60080785",
+    },
+    {
+      from: "60080783",
+      to: "60080785",
+    },
+    {
+      from: "60080786",
+      to: "60080785",
+    },
+    {
+      from: "60080786",
+      to: "60080785",
+      to_end: true,
+    },
+  ],
+  node: [
+    {
+      id: "60080785",
+      sequence: "AC",
+    },
+    {
+      id: "60080783",
+      sequence: "TT",
+    },
+    {
+      id: "60080786",
+      sequence: "GT",
+    },
+  ],
+  path: [
+    {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 21,
+              to_length: 21,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "2",
+        },
+      ],
+      name: "GRCh38.chr14",
+      indexOfFirstBase: "0",
+    },
+  ],
+};
+
+
+export const cycleReads = [
+  {
+    identity: 1,
+    name: "Read0",
+    path: {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "2",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "3",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "4",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "5",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "6",
+        },
+      ],
+    },
+    score: 110,
+    sequence: "GTGTTT",
+  },
+  {
+    identity: 1,
+    name: "Read1",
+    path: {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 1,
+              to_length: 1,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+            offset: 1,
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "2",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "3",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "4",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "5",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 1,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+            offset: -2,
+          },
+          rank: "6",
+        },
+      ],
+    },
+    score: 110,
+    sequence: "TGTTT",
+  },
+  {
+    identity: 1,
+    name: "Read2",
+    path: {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "2",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "3",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "4",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "5",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "6",
+        },
+      ],
+    },
+    score: 110,
+    sequence: "GTGTTT",
+  },
+  {
+    identity: 1,
+    name: "Read3",
+    path: {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "2",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "3",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "4",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "5",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 3,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+            offset: -1,
+          },
+          rank: "6",
+        },
+      ],
+    },
+    score: 110,
+    sequence: "GTACTT",
+  },
+  {
+    identity: 1,
+    name: "Read4",
+    path: {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 1,
+              to_length: 1,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+            offset: 1,
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "2",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "3",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "4",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "5",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 1,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "6",
+        },
+      ],
+    },
+    score: 110,
+    sequence: "TACTT",
+  },
+];
+
 export const reverseAlignmentGraph = {
   edge: [
     {

--- a/src/util/demo-data.js
+++ b/src/util/demo-data.js
@@ -605,6 +605,450 @@ export const cycleReads = [
   },
 ];
 
+export const cycle2Graph = {
+  edge: [
+    {
+      from: "60080783",
+      from_start: true,
+      to: "60080786",
+      to_end: true,
+    },
+    {
+      from: "60080783",
+      from_start: true,
+      to: "60080785",
+    },
+    {
+      from: "60080783",
+      to: "60080785",
+    },
+    {
+      from: "60080786",
+      to: "60080785",
+    },
+    {
+      from: "60080786",
+      to: "60080785",
+      to_end: true,
+    },
+  ],
+  node: [
+    {
+      id: "60080785",
+      sequence: "AC",
+    },
+    {
+      id: "60080783",
+      sequence: "TT",
+    },
+    {
+      id: "60080786",
+      sequence: "GT",
+    },
+  ],
+  path: [
+    {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 21,
+              to_length: 21,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "2",
+        },
+      ],
+      name: "GRCh38.chr14",
+      indexOfFirstBase: "0",
+    },
+  ],
+};
+
+
+export const cycle2Reads = [
+  {
+    identity: 1,
+    name: "Read0",
+    path: {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "2",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "3",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "4",
+        },
+      ],
+    },
+    score: 110,
+    sequence: "GTGTTT",
+  },
+  {
+    identity: 1,
+    name: "Read1",
+    path: {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 1,
+              to_length: 1,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+            offset: 1,
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "2",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "3",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "5",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 1,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+            offset: -2,
+          },
+          rank: "6",
+        },
+      ],
+    },
+    score: 110,
+    sequence: "TGTTT",
+  },
+  {
+    identity: 1,
+    name: "Read2",
+    path: {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "2",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "3",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "4",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "5",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "6",
+        },
+      ],
+    },
+    score: 110,
+    sequence: "GTGTTT",
+  },
+  {
+    identity: 1,
+    name: "Read3",
+    path: {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "1",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "2",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "3",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "4",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "5",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 3,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+            offset: -1,
+          },
+          rank: "6",
+        },
+      ],
+    },
+    score: 110,
+    sequence: "GTACTT",
+  },
+  {
+    identity: 1,
+    name: "Read4",
+    path: {
+      mapping: [
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "2",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "3",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080786",
+          },
+          rank: "4",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 2,
+            },
+          ],
+          position: {
+            node_id: "60080785",
+          },
+          rank: "5",
+        },
+        {
+          edit: [
+            {
+              from_length: 2,
+              to_length: 1,
+            },
+          ],
+          position: {
+            node_id: "60080783",
+          },
+          rank: "6",
+        },
+      ],
+    },
+    score: 110,
+    sequence: "TACTT",
+  },
+];
+
 export const reverseAlignmentGraph = {
   edge: [
     {

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -488,7 +488,7 @@ function createTubeMap() {
   generateLaneAssignment();
 
   if (config.showExonsFlag === true && bed !== null) addTrackFeatures();
-  generateNodeXCoords();
+  //generateNodeXCoords();
 
   if (reads && config.showReads) {
     generateReadOnlyNodeAttributes();
@@ -504,6 +504,8 @@ function createTubeMap() {
       node.internalReads = [];
     });
   }
+
+  generateNodeXCoords();
 
   generateSVGShapesFromPath(nodes, tracks);
   if (DEBUG) {
@@ -1832,6 +1834,8 @@ function generateNodeXCoords() {
   const sortedNodes = nodes.slice();
   sortedNodes.sort(compareNodesByOrder);
   const extra = calculateExtraSpace();
+  console.log("TRACKS", tracks);
+  console.log("EXTRA SPACE", extra);
 
   sortedNodes.forEach((node) => {
     if (node.hasOwnProperty("order")) {

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -886,10 +886,13 @@ function compareReadOutgoingSegmentsByGoingTo(a, b) {
   let pathIndexB = b[1];
   let readIndexA = a[0];
   let readIndexB = b[0];
-  // let readA = reads[a[0]]
-  // let nodeIndexA = readA.path[pathIndexA].node;
+
+  // Segments are first sorted by the the node they end on,
+  // then by a coming-from tiebreaker,
+  // then by length in final node
+  // TODO: Perhaps we should make an exception to first sort by a coming-from when a cycle is involved
   let nodeA = nodes[reads[readIndexA].path[pathIndexA].node];
-  let nodeB = nodes[reads[b[0]].path[pathIndexB].node];
+  let nodeB = nodes[reads[readIndexB].path[pathIndexB].node];
   // Follow the reads' paths until we find the node they diverge at
   // Or, they go through all the same nodes and we do a tiebreaker at the end
   while (nodeA !== null && nodeB !== null && nodeA === nodeB) {
@@ -919,6 +922,7 @@ function compareReadOutgoingSegmentsByGoingTo(a, b) {
 
   // break tie: both reads cover the same nodes and begin at the same position
   // if we've placed some incoming reads first, we can sort the reads based on where they were placed last
+
   let previousValidYA = null;
   let previousValidYB = null;
   let lastPathIndexA = pathIndexA - 1;

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -488,7 +488,6 @@ function createTubeMap() {
   generateLaneAssignment();
 
   if (config.showExonsFlag === true && bed !== null) addTrackFeatures();
-  //generateNodeXCoords();
 
   if (reads && config.showReads) {
     generateReadOnlyNodeAttributes();

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -718,9 +718,6 @@ function placeReadSet(readIDs, node, topMargin) {
   // Turn the read IDs into a set
   let toPlace = new Set(readIDs);
 
-  if (node.name === "1") {
-    console.log("NODE", node);
-  }
   // Get arrays of the read entry/exit/internal-ness records we want to work on
   let incomingReads = node.incomingReads.filter(([readID, pathIndex]) =>
     toPlace.has(readID)
@@ -731,11 +728,6 @@ function placeReadSet(readIDs, node, topMargin) {
   let internalReads = node.internalReads.filter((readID) =>
     toPlace.has(readID)
   );
-
-  if (node.name === "1") {
-    console.log("incomingReads", incomingReads);
-    console.log("ioutgoingReads", outgoingReads);
-  }
 
   // Only actually use the top margin if we have any reads on the node.
   if (


### PR DESCRIPTION
Segments cycling on the first node had strange interactions since segments classified as "outgoing"(if its pathIndex == 0) had different methods of sorting.

Changes are made to how reads are placed outside of nodes when a cycle is detected, and inside of nodes when reads have the same source and destination Node.

- A new tiebreaker is placed in sortByGoingTo for reads that start and end in the same node. Now they're placed based on the endmost node they were placed in, working its way back if there are no y values. Since these reads start and end in the same node, this should start the reads(in the first node) in the same order as the other nodes.

- Segments outside of nodes now detects cycles, defined as the previous and next segments are in the node and going in the same direction. Segments outside of nodes and are between cycles now sort in reverse to keep the layout clean.

- Extra space in between nodes are calculated after reads are added into the tracks variable.

![Cycle1](https://github.com/vgteam/sequenceTubeMap/assets/23585956/0d723990-375b-4037-8871-6860f19dd296)

![Cycle2](https://github.com/vgteam/sequenceTubeMap/assets/23585956/b7666b1a-430f-4dd6-98f2-b67b74bba169)


Closes #321 