### PR TITLE
Extra Space Between Nodes

### DIFF
--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -1937,7 +1937,7 @@ function calculateExtraSpace() {
           rightSideEdges[track.path[i].order] += 1;
         }
       } else {
-        // Track is going to a differnt node, account for space needed to limit rise/fall angle 
+        // Track is going to a different node; account for space needed to limit rise/fall angle 
         const yDifference = Math.abs(track.path[i].y - track.path[i - 1].y);
         //TODO: Extra space should also be accounted when there are too many tracks curving at the nodes
         fallAngleAdjustment[track.path[i].order] = Math.max(yDifference / 17.5, fallAngleAdjustment[track.path[i].order]);
@@ -3687,11 +3687,9 @@ function drawTrackRectangles(rectangles, type, groupTrack) {
     .text((d) => getPopUpTrackText(d.name));
 }
 
-function compareCurvesByLineChanges(a, b) {
+function compareCurvesByXYStartValue(a, b) {
   if (a.xStart < b.xStart) return 1;
   else if (a.xStart > b.xStart) return -1;
-  else if (a.xEnd < b.xEnd) return 1;
-  else if (a.xEnd > b.xEnd) return -1;
   else if (a.yStart > b.yStart) return 1;
   else if (a.yStart < b.yStart) return -1;
   return 0;
@@ -3914,7 +3912,7 @@ function drawTrackCurves(type, groupTrack) {
     }
 
     // Sort curve groups by their starting y value
-    curveGroup.sort(compareCurvesByLineChanges);
+    curveGroup.sort(compareCurvesByXYStartValue);
 
     curveGroup.forEach((curve) => {
       let xAdjusted = null;

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -1939,7 +1939,7 @@ function calculateExtraSpace() {
       } else {
         // Track is going to a differnt node, account for space needed to limit rise/fall angle 
         const yDifference = Math.abs(track.path[i].y - track.path[i - 1].y);
-        fallAngleAdjustment[track.path[i].order] = Math.max(yDifference / 22.5, fallAngleAdjustment[track.path[i].order]);
+        fallAngleAdjustment[track.path[i].order] = Math.max(yDifference / 17.5, fallAngleAdjustment[track.path[i].order]);
       }
     }
   });
@@ -3882,17 +3882,21 @@ function drawTrackCurves(type, groupTrack) {
   );
 
   myTrackCurves.sort(compareCurvesByLineChanges);
+  console.log("myTrackCurves", myTrackCurves);
 
   myTrackCurves.forEach((curve) => {
     const xMiddle = (curve.xStart + curve.xEnd) / 2;
+    const xRightAdjusted = curve.xStart + (curve.xEnd - curve.xStart) * 0.6;
+    const xLeftAdjusted = curve.xStart + (curve.xEnd - curve.xStart) * (1 - 0.6);
     let d = `M ${curve.xStart} ${curve.yStart}`;
-    d += ` C ${xMiddle} ${curve.yStart} ${xMiddle} ${curve.yEnd} ${curve.xEnd} ${curve.yEnd}`;
+    d += ` C ${xLeftAdjusted} ${curve.yStart} ${xRightAdjusted} ${curve.yEnd} ${curve.xEnd} ${curve.yEnd}`;
     d += ` V ${curve.yEnd + curve.width}`;
-    d += ` C ${xMiddle} ${curve.yEnd + curve.width} ${xMiddle} ${
+    d += ` C ${xRightAdjusted} ${curve.yEnd + curve.width} ${xLeftAdjusted} ${
       curve.yStart + curve.width
     } ${curve.xStart} ${curve.yStart + curve.width}`;
     d += " Z";
     curve.path = d;
+
   });
 
   groupTrack


### PR DESCRIPTION
Sometimes tracks don't have enough space to make a smooth transition from node to node. This PR creates extra space between nodes, taking into account the maximum difference in y values between nodes given any track. 

snp1kg-BRCA1
Before:
![snp1kg-BRCA1_before](https://github.com/vgteam/sequenceTubeMap/assets/23585956/2e81979a-9d0c-4a12-a574-85fd2dbdcab6)

After:
![snp1kg-BRCA1_after](https://github.com/vgteam/sequenceTubeMap/assets/23585956/73644e41-9d32-4ba5-93ec-2930f542d92f)

chr1_15608265_15608765
Before:
![chr1_15608265_15608765_before](https://github.com/vgteam/sequenceTubeMap/assets/23585956/240bf795-3f99-4121-9761-b55728891dc8)

After:
![chr1_15608265_15608765_after](https://github.com/vgteam/sequenceTubeMap/assets/23585956/42dc29e4-21cf-43b0-8c2f-d9269d83f33a)

