### PR TITLE
Improve Markdown formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "fs-extra": "^10.1.0",
         "gbz-base": "^0.1.0-alpha.1",
         "gh-pages": "^4.0.0",
-        "markdown-to-jsx": "^7.2.0",
+        "markdown-to-jsx": "^7.4.3",
         "multer": "^1.4.5-lts.1",
         "node-cron": "^3.0.2",
         "patch-package": "^8.0.0",
@@ -13652,9 +13652,9 @@
       }
     },
     "node_modules/markdown-to-jsx": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.2.0.tgz",
-      "integrity": "sha512-3l4/Bigjm4bEqjCR6Xr+d4DtM1X6vvtGsMGSjJYyep8RjjIvcWtrXBS8Wbfe1/P+atKNMccpsraESIaWVplzVg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.3.tgz",
+      "integrity": "sha512-qwu2XftKs/SP+f6oCe0ruAFKX6jZaKxrBfDBV4CthqbVbRQwHhNM28QGDQuTldCaOn+hocaqbmGvCuXO5m3smA==",
       "engines": {
         "node": ">= 10"
       },
@@ -29877,9 +29877,9 @@
       }
     },
     "markdown-to-jsx": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.2.0.tgz",
-      "integrity": "sha512-3l4/Bigjm4bEqjCR6Xr+d4DtM1X6vvtGsMGSjJYyep8RjjIvcWtrXBS8Wbfe1/P+atKNMccpsraESIaWVplzVg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.3.tgz",
+      "integrity": "sha512-qwu2XftKs/SP+f6oCe0ruAFKX6jZaKxrBfDBV4CthqbVbRQwHhNM28QGDQuTldCaOn+hocaqbmGvCuXO5m3smA==",
       "requires": {}
     },
     "material-colors": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fs-extra": "^10.1.0",
     "gbz-base": "^0.1.0-alpha.1",
     "gh-pages": "^4.0.0",
-    "markdown-to-jsx": "^7.2.0",
+    "markdown-to-jsx": "^7.4.3",
     "multer": "^1.4.5-lts.1",
     "node-cron": "^3.0.2",
     "patch-package": "^8.0.0",

--- a/public/help/help.md
+++ b/public/help/help.md
@@ -44,9 +44,9 @@ Keys can use brackets to encode hierarchical structures such as arrays and objec
 
 The key's name should **not** be in quotes.
 
-Example of an array of JSON objects: 
-```
-object = 
+Example of an array of JSON objects:
+
+```json
 [
    {
       "a": "b",
@@ -69,7 +69,8 @@ This array's query string representation would be: `object[0][a]=b&object[1][c]=
    Array of tracks. Tracks are objects consisting of `trackFile`, `trackType`, and `trackColorSettings`.
 
    A track object in JSON format might look like this:
-   ```
+   
+   ```json
    {
       "trackFile": "exampleData/internal/snp1kg-BRCA1.vg.xg",
       "trackType": "graph",
@@ -140,7 +141,8 @@ This array's query string representation would be: `object[0][a]=b&object[1][c]=
 
 
 Examples of links:
-   * Link with preexisting data: 
+   * Link with preexisting data:
+
       ```
       http://127.0.0.1:3001?
       tracks[0][trackFile]=exampleData%2Finternal%2Fsnp1kg-BRCA1.vg.xg&
@@ -153,7 +155,8 @@ Examples of links:
       dataType=built-in&
       simplify=false
       ```
-   * Link with custom data: 
+   * Link with custom data:
+   
       ```
       http://127.0.0.1:3001?
       tracks[1][trackType]=graph&

--- a/public/help/help.md
+++ b/public/help/help.md
@@ -56,7 +56,7 @@ Example of an array of JSON objects:
       "e": {
          "f": "g"
       }
-   }, 
+   } 
 ]
 ```
 


### PR DESCRIPTION
This should fix the Markdown code blocks rendering as inline, by adding space before them.

It also upgrades the Markdown renderer, since there were some new releases.