### PR TITLE
Add HTML Test Reporter

### DIFF
--- a/jesthtmlreporter.config.json
+++ b/jesthtmlreporter.config.json
@@ -1,0 +1,8 @@
+{
+    "pageTitle": "Jest Tests HTML Report",
+    "outputPath": "test-report/test-repot.html",
+    "includeFailureMsg": true,
+    "includeSuiteFailure": true,
+    "includeConsoleLog": true,
+    "sort": "status"
+  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
       "devDependencies": {
         "jest-compact-reporter": "^1.2.9",
         "jest-fetch-mock": "^3.0.3",
+        "jest-html-reporter": "^3.10.2",
         "prettier": "^2.8.8",
         "qs": "^6.11.1"
       },
@@ -3232,11 +3233,11 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dependencies": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3387,11 +3388,11 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -4159,9 +4160,9 @@
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.25.24",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",
@@ -7836,6 +7837,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.2.tgz",
+      "integrity": "sha512-EelsCzH0gMC2YmXuMeaZ3c6md1sUJQxyb1XXc4xaisi/K6qKukqZhKPrEQyRkdNIncgYyLoDTReq0nNyuKerTg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -11953,6 +11963,71 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/jest-html-reporter": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/jest-html-reporter/-/jest-html-reporter-3.10.2.tgz",
+      "integrity": "sha512-XRBa5ylHPUQoo8aJXEEdKsTruieTdlPbRktMx9WG9evMTxzJEKGFMaw5x+sQxJuClWdNR72GGwbOaz+6HIlksA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^29.0.2",
+        "@jest/types": "^29.0.2",
+        "dateformat": "3.0.2",
+        "mkdirp": "^1.0.3",
+        "strip-ansi": "6.0.1",
+        "xmlbuilder": "15.0.0"
+      },
+      "engines": {
+        "node": ">=4.8.3"
+      },
+      "peerDependencies": {
+        "jest": "19.x - 29.x",
+        "typescript": "^3.7.x || ^4.3.x || ^5.x"
+      }
+    },
+    "node_modules/jest-html-reporter/node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-html-reporter/node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-html-reporter/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-jasmine2": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.5.1.tgz",
@@ -12160,17 +12235,17 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/jest-message-util": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
-      "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.5.0",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -12190,11 +12265,11 @@
       }
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -12731,11 +12806,11 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/jest-util": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
-      "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -19788,6 +19863,15 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
     },
+    "node_modules/xmlbuilder": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.0.0.tgz",
+      "integrity": "sha512-KLu/G0DoWhkncQ9eHSI6s0/w+T4TM7rQaLhtCaL6tORv8jFlJPlnGumsgTcGfYeS1qZ/IHqrvDG7zJZ4d7e+nw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -22051,11 +22135,11 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "requires": {
-        "@sinclair/typebox": "^0.25.16"
+        "@sinclair/typebox": "^0.27.8"
       }
     },
     "@jest/source-map": {
@@ -22182,11 +22266,11 @@
       }
     },
     "@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "requires": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -22650,9 +22734,9 @@
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
     },
     "@sinclair/typebox": {
-      "version": "0.25.24",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
     },
     "@sinonjs/commons": {
       "version": "1.8.6",
@@ -25448,6 +25532,12 @@
       "requires": {
         "@babel/runtime": "^7.21.0"
       }
+    },
+    "dateformat": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.2.tgz",
+      "integrity": "sha512-EelsCzH0gMC2YmXuMeaZ3c6md1sUJQxyb1XXc4xaisi/K6qKukqZhKPrEQyRkdNIncgYyLoDTReq0nNyuKerTg==",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",
@@ -28505,6 +28595,54 @@
         }
       }
     },
+    "jest-html-reporter": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/jest-html-reporter/-/jest-html-reporter-3.10.2.tgz",
+      "integrity": "sha512-XRBa5ylHPUQoo8aJXEEdKsTruieTdlPbRktMx9WG9evMTxzJEKGFMaw5x+sQxJuClWdNR72GGwbOaz+6HIlksA==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^29.0.2",
+        "@jest/types": "^29.0.2",
+        "dateformat": "3.0.2",
+        "mkdirp": "^1.0.3",
+        "strip-ansi": "6.0.1",
+        "xmlbuilder": "15.0.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+          "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.6.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+          "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        }
+      }
+    },
     "jest-jasmine2": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.5.1.tgz",
@@ -28673,17 +28811,17 @@
       }
     },
     "jest-message-util": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
-      "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.5.0",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -28694,11 +28832,11 @@
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
         },
         "pretty-format": {
-          "version": "29.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-          "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "requires": {
-            "@jest/schemas": "^29.4.3",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           }
@@ -29149,11 +29287,11 @@
       }
     },
     "jest-util": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
-      "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "requires": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -34226,6 +34364,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xmlbuilder": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.0.0.tgz",
+      "integrity": "sha512-KLu/G0DoWhkncQ9eHSI6s0/w+T4TM7rQaLhtCaL6tORv8jFlJPlnGumsgTcGfYeS1qZ/IHqrvDG7zJZ4d7e+nw==",
+      "dev": true
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "start": "concurrently -n frontend,backend -c red,green 'HOST=${HOST:=127.0.0.1} PORT=${PORT:=3001} react-scripts start' 'npm:serve'",
     "build": "react-scripts build",
-    "test": "react-scripts test --reporters default jest-compact-reporter --seed=1",
+    "test": "react-scripts test --testResultsProcessor=./node_modules/jest-html-reporter --reporters default jest-compact-reporter --seed=1",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
@@ -85,6 +85,7 @@
   "devDependencies": {
     "jest-compact-reporter": "^1.2.9",
     "jest-fetch-mock": "^3.0.3",
+    "jest-html-reporter": "^3.10.2",
     "prettier": "^2.8.8",
     "qs": "^6.11.1"
   },


### PR DESCRIPTION
`npm run test` now includes an HTML file in the test_report directory, showing test results more clearly.

![HTML_Test_Report](https://github.com/vgteam/sequenceTubeMap/assets/23585956/4aafbe86-8a78-44a6-aa51-3ec43ac9cc90)
