### PR TITLE
Add a script that can batch import and explain Lancet data in the November format

### DIFF
--- a/scripts/prepare_lancet_output.sh
+++ b/scripts/prepare_lancet_output.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# prepare_lancet_input.sh: Turn a directory of Lancet output into a Tube Map BED file and directory that can be hosted on the web.
+set -x
+
+function usage() {
+    echo >&2 "${0}: Prepare a directory of Lancet data ."
+    echo >&2
+    echo >&2 "The input directory should have in it:"
+    echo >&2 "- variant_calling_regions.with_calls.bed, an extended BED file with biallelic VCF REF in column 6, ALT in column 7, and INFO in column 9 with a TYPE field"
+    echo >&2 "- giraffe_alignments/, a directory with, for each VCF record:"
+    echo >&2 "    - <CONTIG>_<START>_<END>.giraffe.gbz"
+    echo >&2 "    - normal.<CONTIG>_<START>_<END>.gam"
+    echo >&2 "    - tumor.<CONTIG>_<START>_<END>.gam"
+    echo >&2 "Note that it is tolerated for the END used in the file names to not match the one used in the BED records."
+    echo >&2
+    echo >&2 "Usage: ${0} <INPUT_DIR> <OUTPUT_DIR>"
+    exit 1
+}
+
+INPUT_DIR="${1}"
+OUTPUT_DIR="${2}"
+
+if [[ -z "${OUTPUT_DIR}" || -z "${INPUT_DIR}" || ! -d "${INPUT_DIR}" ]] ; then
+    usage
+fi
+
+# Make all the paths absolute
+INPUT_DIR="$(realpath "${INPUT_DIR}")"
+OUTPUT_DIR="$(realpath "${OUTPUT_DIR}")"
+
+INPUT_BED="${INPUT_DIR}/variant_calling_regions.with_calls.bed"
+INPUT_DATA_DIR="${INPUT_DIR}/giraffe_alignments"
+
+if [[ ! -f "${INPUT_BED}" || ! -d "${INPUT_DATA_DIR}" ]] ; then
+    usage
+fi
+
+
+SCRIPTS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+mkdir -p "${OUTPUT_DIR}"
+
+OUTPUT_BED="${OUTPUT_DIR}/index.bed"
+rm -f "${OUTPUT_BED}"
+
+# We need to ber in the output directory to use relative paths in the generated BED.
+cd "${OUTPUT_DIR}"
+
+while IFS="" read -r INPUT_LINE || [[ -n "${INPUT_LINE}" ]] ; do
+    # Read all the lines, even if the newline is missing. See <https://stackoverflow.com/a/1521498>
+
+    # Parse the BED
+    CONTIG="$(echo "${INPUT_LINE}" | cut -f1)"
+    START_POS="$(echo "${INPUT_LINE}" | cut -f2)"
+    END_POS="$(echo "${INPUT_LINE}" | cut -f3)"
+    REF_SEQ="$(echo "${INPUT_LINE}" | cut -f6)"
+    ALT_SEQ="$(echo "${INPUT_LINE}" | cut -f7)"
+    INFO="$(echo "${INPUT_LINE}" | cut -f9)"
+
+    # Fetch out the type (MNP, INS, etc.)
+    VARIANT_TYPE="$(echo "${INFO}" | grep -o "TYPE=[A-Z]*" | cut -f2 -d'=')"
+    
+
+    # End positions on the variants are not actually the end positions used in
+    # the filenames. So find the right graph based only on the start position.
+    INPUT_GRAPH="$(find "${INPUT_DATA_DIR}" -name "${CONTIG}_${START_POS}_*.giraffe.gbz")"
+    INPUT_GRAPH_BASENAME="$(basename "${INPUT_GRAPH}")"
+    SLUG="${INPUT_GRAPH_BASENAME%.giraffe.gbz}"
+    
+    INPUT_NORMAL_GAM="${INPUT_DATA_DIR}/normal.${SLUG}.gam"
+    INPUT_TUMOR_GAM="${INPUT_DATA_DIR}/tumor.${SLUG}.gam"
+    
+    # Make the chunk directory
+    "${SCRIPTS_DIR}/prepare_local_chunk.sh" \
+         -x "${INPUT_GRAPH}" \
+         -g "${INPUT_NORMAL_GAM}" \
+         -p '{"mainPalette": "blues", "auxPalette": "blues"}' \
+         -g "${INPUT_TUMOR_GAM}" \
+         -p '{"mainPalette": "reds", "auxPalette": "reds"}' \
+         -r "${CONTIG}:${START_POS}-${END_POS}" \
+         -d "Tumor-specific ${REF_SEQ} -> ${ALT_SEQ} ${VARIANT_TYPE} variant" \
+         -o "${SLUG}" \
+         >>"${OUTPUT_BED}"
+
+    # We want to hide the path cover paths from Giraffe and only show the paths from the original Lancet GFA
+    vg paths --drop-paths --paths-by "path_cover_" -x "${SLUG}/chunk.vg" >"${SLUG}/chunk.vg.new"
+    mv "${SLUG}/chunk.vg.new" "${SLUG}/chunk.vg"
+
+done <"${INPUT_BED}"

--- a/scripts/prepare_lancet_output.sh
+++ b/scripts/prepare_lancet_output.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # prepare_lancet_input.sh: Turn a directory of Lancet output into a Tube Map BED file and directory that can be hosted on the web.
-set -x
 
 function usage() {
     echo >&2 "${0}: Prepare a directory of Lancet data ."
@@ -11,7 +10,7 @@ function usage() {
     echo >&2 "    - <CONTIG>_<START>_<END>.giraffe.gbz"
     echo >&2 "    - normal.<CONTIG>_<START>_<END>.gam"
     echo >&2 "    - tumor.<CONTIG>_<START>_<END>.gam"
-    echo >&2 "Note that it is tolerated for the END used in the file names to not match the one used in the BED records."
+    echo >&2 "The ranges in the file named will not correspond exactly to those in the BED records; files for a range overlapping and centered on the BED record will be used."
     echo >&2
     echo >&2 "Usage: ${0} <INPUT_DIR> <OUTPUT_DIR>"
     exit 1
@@ -51,34 +50,87 @@ while IFS="" read -r INPUT_LINE || [[ -n "${INPUT_LINE}" ]] ; do
 
     # Parse the BED
     CONTIG="$(echo "${INPUT_LINE}" | cut -f1)"
-    START_POS="$(echo "${INPUT_LINE}" | cut -f2)"
-    END_POS="$(echo "${INPUT_LINE}" | cut -f3)"
+    # These are 0-based, end-exclusive coordinates
+    START_BED_POS="$(echo "${INPUT_LINE}" | cut -f2)"
+    END_BED_POS="$(echo "${INPUT_LINE}" | cut -f3)"
     REF_SEQ="$(echo "${INPUT_LINE}" | cut -f6)"
     ALT_SEQ="$(echo "${INPUT_LINE}" | cut -f7)"
     INFO="$(echo "${INPUT_LINE}" | cut -f9)"
 
+    # Compute 1-based, end-inclusive coordinates
+    START_POS=$((START_BED_POS+1))
+    END_POS="${END_BED_POS}"
+
     # Fetch out the type (MNP, INS, etc.)
     VARIANT_TYPE="$(echo "${INFO}" | grep -o "TYPE=[A-Z]*" | cut -f2 -d'=')"
-    
 
-    # End positions on the variants are not actually the end positions used in
-    # the filenames. So find the right graph based only on the start position.
-    INPUT_GRAPH="$(find "${INPUT_DATA_DIR}" -name "${CONTIG}_${START_POS}_*.giraffe.gbz")"
+    # Find the best overlapping graph file.
+    # These are the 1-based, end-exclusive coordinates from the filenames
+    BEST_START=""
+    BEST_END=""
+    # These are the 0-based, end-exclusive coordinates
+    BEST_BED_START=""
+    BEST_BED_END=""
+    # This is how many more bases are on one side fo the variant than are on the other
+    BEST_UNEVENNESS=""
+
+    CANDIDATES=("${INPUT_DATA_DIR}/${CONTIG}_"*".giraffe.gbz")
+    for GRAPH_FILE in "${CANDIDATES[@]}" ; do
+        GRAPH_BASENAME="$(basename "${GRAPH_FILE}")"
+        # Work out the region this graph covers. Remember to convert to 1-based
+        GRAPH_START="$(echo "${GRAPH_BASENAME%.giraffe.gbz}" | cut -f2 -d'_')"
+        GRAPH_END="$(echo "${GRAPH_BASENAME%.giraffe.gbz}" | cut -f3 -d'_')"
+
+        # Convert to 0-based, end-exclusive
+        GRAPH_BED_START=$((GRAPH_START-1))
+        GRAPH_BED_END="${GRAPH_END}"
+
+        BEFORE_BASES=$((START_BED_POS-GRAPH_BED_START))
+        AFTER_BASES=$((GRAPH_BED_END-END_BED_POS))
+        if [[ "${BEFORE_BASES}" -lt 0 || "${AFTER_BASES}" -lt 0 ]] ; then
+            # This graph does not overlap the variant we are working on
+            continue
+        fi
+
+        # Work out how uneven the centering is
+        if [[ "${BEFORE_BASES}" -gt "${AFTER_BASES}" ]] ; then
+            UNEVENNESS=$((BEFORE_BASES-AFTER_BASES))
+        else
+            UNEVENNESS=$((AFTER_BASES-BEFORE_BASES))
+        fi
+
+        if [[ -z "${BEST_UNEVENNESS}" || "${BEST_UNEVENNESS}" -gt "${UNEVENNESS}" ]] ; then
+            # This is the best graph so far
+            BEST_START="${GRAPH_START}"
+            BEST_END="${GRAPH_END}"
+            BEST_BED_START="${GRAPH_BED_START}"
+            BEST_BED_END="${GRAPH_BED_END}"
+            BEST_UNEVENNESS="${UNEVENNESS}"
+        fi
+    done
+
+    if [[ -z "${BEST_START}" ]] ; then
+        echo >&2 "No graph in ${INPUT_DATA_DIR} overlaps the variant ${INPUT_LINE}"
+        exit 1
+    fi
+
+    # Find the best graph again
+    INPUT_GRAPH="$(find "${INPUT_DATA_DIR}" -name "${CONTIG}_${BEST_START}_${BEST_END}.giraffe.gbz")"
     INPUT_GRAPH_BASENAME="$(basename "${INPUT_GRAPH}")"
     SLUG="${INPUT_GRAPH_BASENAME%.giraffe.gbz}"
     
     INPUT_NORMAL_GAM="${INPUT_DATA_DIR}/normal.${SLUG}.gam"
     INPUT_TUMOR_GAM="${INPUT_DATA_DIR}/tumor.${SLUG}.gam"
     
-    # Make the chunk directory
+    # Make the chunk directory. Remember to use a 1-based, end-inclusive range and description coordinates.
     "${SCRIPTS_DIR}/prepare_local_chunk.sh" \
          -x "${INPUT_GRAPH}" \
          -g "${INPUT_NORMAL_GAM}" \
          -p '{"mainPalette": "blues", "auxPalette": "blues"}' \
          -g "${INPUT_TUMOR_GAM}" \
          -p '{"mainPalette": "reds", "auxPalette": "reds"}' \
-         -r "${CONTIG}:${START_POS}-${END_POS}" \
-         -d "Tumor-specific ${REF_SEQ} -> ${ALT_SEQ} ${VARIANT_TYPE} variant" \
+         -r "${CONTIG}:${BEST_START}-${BEST_END}" \
+         -d "Tumor-specific ${REF_SEQ} -> ${ALT_SEQ} ${VARIANT_TYPE} variant at ${CONTIG}:${START_POS}" \
          -o "${SLUG}" \
          >>"${OUTPUT_BED}"
 

--- a/src/components/CopyLink.js
+++ b/src/components/CopyLink.js
@@ -86,13 +86,17 @@ export const urlParamsToViewTarget = (url) => {
     result = qs.parse(s[1]);
   }
 
-  // Ensures that the simplify field is a boolean, as the qs module can't tell
+  
+
+  // Ensures that the flag fields are booleans, as the qs module can't tell
   // the difference between false and "false"
   if (result != null) {
-    if (result.simplify === "true") {
-      result.simplify = true;
-    } else if (result.simplify === "false") {
-      result.simplify = false;
+    for (let flag_name of ["simplify", "removeSequences"]) {
+      if (result[flag_name] === "true") {
+        result[flag_name] = true;
+      } else if (result[flag_name] === "false") {
+        result[flag_name] = false;
+      }
     }
   }
 

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -1828,12 +1828,17 @@ async function getBedRegions(bed) {
   }
 
   lines = bed_data.split(/\r?\n/);
-  lines.map(function (line) {
+  
+  for (let [index, line] of lines.entries()) {
     let records = line.split("\t");
 
     if (records.length < 3) {
       // This is an empty line or otherwise not BED
-      return;
+      if (line !== "") {
+        // This is a bad line
+        throw new BadRequestError("BED line " + (index + 1) + " could not be parsed");
+      }
+      continue;
     }
     bed_info["chr"].push(records[0]);
     bed_info["start"].push(records[1]);
@@ -1848,7 +1853,11 @@ async function getBedRegions(bed) {
       chunk = records[4];
     }
     bed_info["chunk"].push(chunk);
-  });
+  }
+
+  if (bed_info.length === 0) {
+    BadRequestError("BED file is empty");
+  }
 
   // check for a tracks.json file to prefill tracks configuration
   for (let i = 0; i < bed_info["chunk"].length; i++) {

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -661,14 +661,16 @@ function placeReads() {
 
   // Space out read tracks if multiple exist
   let topMargin = allSources.length > 1 ? READ_WIDTH : 0;
-  for (let source of allSources) {
-    // Go through all source tracks in order
-    sortedNodes.forEach((node) => {
-      // And for each node, place these reads in it.
+  sortedNodes.forEach((node) => {
+    // For each node
+    for (let source of allSources) {
+      // Go through all source tracks in order
+      
+      // Place the reads from this source in this node.
       // Use a margin to separate multiple read tracks if we have them.
       placeReadSet(readsBySource[source], node, topMargin);
-    });
-  }
+    }
+  });
 
   // place read segments which are without node
   const bottomY = calculateBottomY();

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -318,7 +318,7 @@ export function changeAllTracksVisibility(value) {
   let i = 0;
   while (i < inputTracks.length) {
     inputTracks[i].hidden = !value;
-    var checkbox = document.getElementById(`showTrack${i}`);
+    var checkbox = document.getElementById(`showTrack${inputTracks[i].id}`);
     checkbox.checked = value;
     i += 1;
   }
@@ -4070,6 +4070,7 @@ function drawLegend() {
   content +=
     '<table class="table-sm table-condensed table-nonfluid"><thead><tr><th>Color</th><th>Trackname</th><th>Show Track</th></tr></thead>';
   const listeners = [];
+  // This is in terms of tracks, but when we change visibility we need to touch inputTracks, so we need to set up listeners by track ID.
   for (let i = 0; i < tracks.length; i += 1) {
     if (tracks[i].type === "haplo") {
       content += `<tr><td style="text-align:right"><div class="color-box" style="background-color: ${generateTrackColor(
@@ -4081,17 +4082,17 @@ function drawLegend() {
       } else {
         content += `<td>${tracks[i].id}</td>`;
       }
-      content += `<td><input type="checkbox" checked=true id="showTrack${i}"></td>`;
-      listeners.push(i);
+      content += `<td><input type="checkbox" checked=true id="showTrack${tracks[i].id}"></td>`;
+      listeners.push(tracks[i].id);
     }
   }
   content += "</table";
   // $('#legendDiv').html(content);
   document.getElementById("legendDiv").innerHTML = content;
-  listeners.forEach((i) => {
+  listeners.forEach((id) => {
     document
-      .getElementById(`showTrack${i}`)
-      .addEventListener("click", () => changeTrackVisibility(i), false);
+      .getElementById(`showTrack${id}`)
+      .addEventListener("click", () => changeTrackVisibility(id), false);
   });
   document
     .getElementById("selectall")


### PR DESCRIPTION
This fixes #427 sort of by making a BED that explains what variant is supposed to be seen.

I ran it like this:
```
cd ~/workspace/sequenceTubeMap
mkdir -p webhost
cd webhost

~/workspace/sequenceTubeMap/scripts/prepare_lancet_output.sh ~/Downloads/STM_DataShare_Nov07_2023\ 2/ ./lancet_2023-11-07

cd lancet_2023-11-07

python3 -m http.server
```

Then I could put `http://[::]:8000/index.bed` into my local tube map as the BED file and browse the data.

But, I think the data provided is not exactly what I really want to look at. It looks liek the called tumor variants are not actually *in* the graphs. For example, at `chr1:38506973-38506974` I am suppsoed to see a `Tumor-specific CTGGAATCCAGCAGCCCAGACTTCCACATCATAATTTTCTGGGGCAATGGTTTTCAAACTTCACTGTACG -> C DEL variant`. But the graph doesn't show a large deletion. Instead, that deleted sequence occurs 1 base into the leftmost node here, and I can see the softclips in the aligned tumor reads at their left ends, where they would read over the deletion edge that isn't present. Here's a screenshot of the softclips, with the tumor reads in red:

![Screenshot 2024-05-03 at 16 56 40](https://github.com/vgteam/sequenceTubeMap/assets/5062495/1c3a4c64-af18-4962-b0a3-e46bd761af6c)

So I now have a way to generate and host tumor-normal Lancet examples, including examples for larger indels, but the graphs coming from Lancet don't really seem to be the right ones.
