### PR TITLE
Parse path name lines live and festoon callbacks with error handling

### DIFF
--- a/scripts/prepare_vg.sh
+++ b/scripts/prepare_vg.sh
@@ -10,11 +10,10 @@ fi
 echo "${1}"
 echo "${1%.vg}"
 
-if [[ -e "${1%.vg}.vcf.gz" && -e "${1%.vg}.vcf.gz.tbi" ]]
-then
-    echo "Generating xg index and gbwt index from vg file and VCF"
-    vg index "${1}" -v "${1%.vg}.vcf.gz" -x "${1}.xg" --gbwt-name "${1}.gbwt"
-else
-    echo "Generating xg index from vg file"
-    vg index "${1}" -x "${1}.xg"
+echo "Generating xg index ${1}.xg from vg file"
+vg convert "${1}" -x >"${1}.xg"
+
+if [[ -e "${1%.vg}.vcf.gz" && -e "${1%.vg}.vcf.gz.tbi" ]] ; then
+    echo "Generating gbwt index ${1}.gbwt from vg file and VCF"
+    vg gbwt -x "${1}" -v "${1%.vg}.vcf.gz" -o "${1}.gbwt"
 fi

--- a/src/errors.mjs
+++ b/src/errors.mjs
@@ -1,0 +1,38 @@
+/// errors.mjs: Error type definitions for the tube map server
+
+// We can throw this error to trigger our error handling code instead of
+// Express's default. It covers input validation failures, and vaguely-expected
+// server-side errors we want to report in a controlled way (because they could
+// be caused by bad user input to vg).
+export class TubeMapError extends Error {
+  constructor(message) {
+    super(message);
+  }
+}
+
+// We can throw this error to make Express respond with a bad request error
+// message. We should throw it whenever we detect that user input is
+// unacceptable.
+export class BadRequestError extends TubeMapError {
+  constructor(message) {
+    super(message);
+    this.status = 400;
+  }
+}
+
+// We can throw this error to make Express respond with an internal server
+// error message
+export class InternalServerError extends TubeMapError {
+  constructor(message) {
+    super(message);
+    this.status = 500;
+  }
+}
+
+// We can throw this error to make Express respond with an internal server
+// error message about vg.
+export class VgExecutionError extends InternalServerError {
+  constructor(message) {
+    super(message);
+  }
+}

--- a/src/scripts.test.js
+++ b/src/scripts.test.js
@@ -1,0 +1,62 @@
+// Tests for data imp[ort scripts, to make sure vg still supports them.
+
+import "./config-server.mjs";
+
+import { find_vg } from "./vg.mjs";
+
+import { mkdtemp, rm, cp, open, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import child_process from 'node:child_process';
+import { promisify } from 'node:util';
+
+// This runs a command string and returns a promise for {stdout, stderr} that
+// rejects if the command fails.
+const exec = promisify(child_process.exec);
+
+// This takes a command file and an array of arguments and returns a promise
+// for {stdout, stderr} that rejects if the command fails.
+const execFile = promisify(child_process.execFile);
+
+const EXAMPLE_DATA = join(__dirname, "..", "exampleData");
+const SCRIPTS = join(__dirname, "..", "scripts");
+
+// We set this to a fresh empty directory for each test.
+let workDir = null;
+
+beforeEach(async () => {
+  // Each test gets a fresh directory
+  workDir = await mkdtemp(join(tmpdir(), 'test-'));
+});
+
+afterEach(async () => {
+  if (workDir) {
+    rm(workDir, {force: true, recursive: true});
+  }
+});
+
+it("can run prepare_vg.sh", async () => {
+  for (let filename of ["x.fa", "x.vcf.gz", "x.vcf.gz.tbi"]) {
+    // Get all the input data
+    await cp(join(EXAMPLE_DATA, filename), join(workDir, filename));
+  }
+  
+  // Build the graph
+  const vgBuffer = (await execFile(find_vg(), ["construct", "-r", join(workDir, "x.fa"), "-v", join(workDir, "x.vcf.gz"), "-a"], {encoding: "buffer"})).stdout
+  const graphPath = join(workDir, "x.vg");
+  console.log("Save graph to " + graphPath);
+  let file = await open(graphPath, "w");
+  await file.writeFile(vgBuffer);
+  await file.close();
+
+  // Do the call under test
+  // We can't use expect here because await expect(...).resolves doesn't actually detect rejections.
+  console.log("Call script");
+  let {stdout, stderr} = await execFile(join(SCRIPTS, "prepare_vg.sh"), [join(workDir, "x.vg")]);
+  console.log("stdout:", stdout);
+  console.log("stderr:", stderr);
+  await access(join(workDir, "x.vg.xg"));
+  await access(join(workDir, "x.vg.gbwt"));
+});
+
+

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -1731,7 +1731,7 @@ api.post("/getPathNames", (req, res, next) => {
   // there are more than fit in a Node string.
   let pathNames = [];
   const lineReader = rl.createInterface({
-    input: fs.createReadStream(vgViewChild.stdout),
+    input: vgViewChild.stdout,
   });
 
   

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -1061,11 +1061,17 @@ async function getChunkedData(req, res, next) {
 /// to the requested region are first, and return a re-ordered array of paths.
 function organizePathsTargetFirst(region, pathList) {
   if (region.contig !== "node") {
+    
+    // We pull the subrange off the path names when comparing them
+    let subrange_regex = /\[[0-9]+(-[0-9]+)?\]$/;
+    let targetBasePath = region.contig.replace(subrange_regex, "");
+
     // Make sure that path 0 is the path we actually asked about
     let refPaths = [];
     let otherPaths = [];
     for (let path of pathList) {
-      if (path.name === region.contig) {
+      let pathBasePath = path.name.replace(subrange_regex, "");
+      if (pathBasePath === targetBasePath) {
         // This is the path we asked about, so it goes first
         refPaths.push(path);
       } else {

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -3598,8 +3598,10 @@ function drawRuler() {
     return xCoordOfMarking;
   }
 
-  let start_region = Number(inputRegion[0]);
-  let end_region = Number(inputRegion[1]);
+  // Get the region in bp in the scale bar's coordinate space to highlight as
+  // the target region. Will be null if we're using node IDs.
+  let start_region = inputRegion[0] !== null ? Number(inputRegion[0]) : null;
+  let end_region = inputRegion[1] !== null ? Number(inputRegion[1]) : null;
 
   let intervalsVisitedByNodes = [];
 
@@ -3626,6 +3628,7 @@ function drawRuler() {
     let alreadyMarkedNode = false;
 
     if (
+      start_region !== null &&
       start_region >= indexOfFirstBaseInNode &&
       start_region < indexOfFirstBaseInNode + currentNode.sequenceLength
     ) {
@@ -3639,6 +3642,7 @@ function drawRuler() {
       ticks_region.push([start_region, xCoordOfMarking]);
     }
     if (
+      end_region !== null &&
       end_region >= indexOfFirstBaseInNode &&
       end_region < indexOfFirstBaseInNode + currentNode.sequenceLength
     ) {

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -2654,7 +2654,7 @@ function generateTrackColor(track, highlight) {
     }
   } else {
     if (config.showExonsFlag === false || highlight !== "plain") {
-      // Don't repeat the color of the first track (reference) to highilight is better.
+      // Don't repeat the color of the first track (reference) to highlight is better.
       // TODO: Allow using color 0 for other schemes not the same as the one for the reference path.
       // TODO: Stop reads from taking this color?
       const auxColorSet = getColorSet(config.colorSchemes[sourceID].auxPalette);

--- a/src/vg.mjs
+++ b/src/vg.mjs
@@ -1,0 +1,56 @@
+import { config } from "./config-global.mjs";
+import { InternalServerError } from "./errors.mjs";
+
+import fs from "fs-extra";
+import which from "which";
+
+/// Return the command string to execute to run vg.
+/// Checks config.vgPath.
+/// An entry of "" in config.vgPath means to check PATH.
+export function find_vg() {
+  if (find_vg.found_vg !== null) {
+    // Cache the answer and don't re-check all the time.
+    // Nobody should be deleting vg.
+    return find_vg.found_vg;
+  }
+  for (let prefix of config.vgPath) {
+    if (prefix === "") {
+      // Empty string has special meaning of "use PATH".
+      console.log("Check for vg on PATH");
+      try {
+        find_vg.found_vg = which.sync("vg");
+        console.log("Found vg at:", find_vg.found_vg);
+        return find_vg.found_vg;
+      } catch (e) {
+        // vg is not on PATH
+        continue;
+      }
+    }
+    if (prefix.length > 0 && prefix[prefix.length - 1] !== "/") {
+      // Add trailing slash
+      prefix = prefix + "/";
+    }
+    let vg_filename = prefix + "vg";
+    console.log("Check for vg at:", vg_filename);
+    if (fs.existsSync(vg_filename)) {
+      if (!fs.statSync(vg_filename).isFile()) {
+        // This is a directory or something, not a binary we can run.
+        continue;
+      }
+      try {
+        // Pretend we will execute it
+        fs.accessSync(vg_filename, fs.constants.X_OK)
+      } catch (e) {
+        // Not executable
+        continue;
+      }
+      // If we get here it is executable.
+      find_vg.found_vg = vg_filename;
+      console.log("Found vg at:", find_vg.found_vg);
+      return find_vg.found_vg;
+    }
+  }
+  // If we get here we don't see vg at all.
+  throw new InternalServerError("The vg command was not found. Install vg to use the Sequence Tube Map: https://github.com/vgteam/vg?tab=readme-ov-file#installation");
+}
+find_vg.found_vg = null;


### PR DESCRIPTION
This should fix #472 in two ways.

We no longer make one giant string of all the path names (though we do call `res.json()` with one giant object), and we now have some error handlers in the callbacks in that call (but not others) that catch errors and call `next()`.