### PR TITLE
Revise server port docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,17 @@ After installation, you can run the Sequence Tube Map:
     ```
     Note that this is using **npm**, not **nvm** as in the previous step.
 
-    If you get an `EADDRINUSE` error, try picking a different server port (and update all the numbers below from 3001 to whatever you picked).
+    If you get an `EADDRINUSE` error, try picking a different server port (and update all the numbers below from 3000 to whatever you picked).
     ```
-    SERVER_PORT=3009 npm run serve
+    SERVER_PORT=3001 npm run serve
     ```
 5. Open the Sequence Tube Map in your browser.
-    - If you are running the Sequence Tube Map on your local computer, you can visit [http://localhost:3001](http://localhost:3001).
-    - If you are running the Sequence Tube Map on a *different* computer (for example, one accessed by SSH), you will need to connect to it there. You can try browsing to port 3001 on that machine's hostname. For example, if you connected with `ssh yourname@bigserver.example.edu`, then `bigserver.example.edu` is the hostname, and you want to visit `http://bigserver.example.edu:3001`. If that doesn't work, you can try setting up an SSH tunnel by making a second SSH connection with:
+    - If you are running the Sequence Tube Map on your local computer, you can visit [http://localhost:3000](http://localhost:3000).
+    - If you are running the Sequence Tube Map on a *different* computer (for example, one accessed by SSH), you will need to connect to it there. You can try browsing to port 3000 on that machine's hostname. For example, if you connected with `ssh yourname@bigserver.example.edu`, then `bigserver.example.edu` is the hostname, and you want to visit `http://bigserver.example.edu:3000`. If that doesn't work, you can try setting up an SSH tunnel by making a second SSH connection with:
         ```
-        ssh -L 3001:localhost:3001 yourname@bigserver.example.edu
+        ssh -L 3000:localhost:3000 yourname@bigserver.example.edu
         ```
-        While that SSH connection is open, you will be able to see the Sequence Tube Map at [http://localhost:3001](http://localhost:3001).
+        While that SSH connection is open, you will be able to see the Sequence Tube Map at [http://localhost:3000](http://localhost:3000).
 
 ### Setting Up a Visualization
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -12,7 +12,7 @@ The `npm run build`/`npm run serve` pipeline can only produce minified code, whi
   ```
   npm run start
   ```
-This will use React's development mode server to serve the frontend, and run the backend in a separate process, behind React's proxy. Local ports 3000 (or set a different SERVER_PORT in .env) and 3001 (or set a different PORT in the environment for the command) must both be free.
+This will use React's development mode server to serve the frontend, and run the backend in a separate process, behind React's proxy. Local ports 3000 and 3001 must both be free. You can change these with the `SERVER_PORT` environment variable or `.env` setting, or the `serverPort` field in `config.json`, and the `PORT` environment variable.
 
 Running in this mode allows the application to produce human-readable stack traces when something goes wrong in the browser.
 

--- a/package.json
+++ b/package.json
@@ -62,13 +62,13 @@
     "worker-rpc": "^0.2.0"
   },
   "scripts": {
-    "start": "SERVER_PORT=${SERVER_PORT:=3000} concurrently -n frontend,backend -c red,green 'HOST=${HOST:=127.0.0.1} PORT=${PORT:=3001} react-scripts start' 'npm:serve'",
+    "start": "concurrently -n frontend,backend -c red,green 'HOST=${HOST:=127.0.0.1} PORT=${PORT:=3001} react-scripts start' 'npm:serve'",
     "build": "react-scripts build",
     "test": "react-scripts test --testResultsProcessor=./node_modules/jest-html-reporter --reporters default jest-compact-reporter --seed=1",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
-    "serve": "SERVER_PORT=${SERVER_PORT:=3001} node ./src/server.mjs",
+    "serve": "node ./src/server.mjs",
     "format": "prettier --write \"**/*.+(mjs|js|css)\"",
     "postinstall": "patch-package"
   },


### PR DESCRIPTION
This should fix #476 by changing the docs to point at the port we actually run the server from `npm run serve` on, and documenting how to move it on the command line and why you might need to.

I wanted to move the `npm run serve` user-facing port you actually need to browse to to be 3001, the same as the `npm run start` one, but I couldn't work out how to do that while respecting `config.json`'s `serverPort` *and* not needing new config for the demo deployment.