### PR TITLE
Better region markings

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -1424,6 +1424,11 @@ function processRegionFile(req, res, next) {
           console.log("Rename " + subpathName + " to " + arr[0] + " and mark start as " + arr[1]);
           p.name = arr[0];
           p.indexOfFirstBase = arr[1];
+        } else if (p.name === arr[0]) {
+          // We might be looking at a pre-extracted region that predates real
+          // subpath support (like the Lancet paper data), in which case we
+          // need to grab the real start point from the regions file.
+          p.indexOfFirstBase = arr[1];
         }
       });
     });

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -3715,7 +3715,7 @@ function drawRuler() {
   });
   ticks = separatedTicks;
 
-  // plot ticks highlighting the region
+  // plot ticks highlighting the region (if it is filled in)
   drawRulerMarkingRegion(ticks_region);
 
   // draw horizontal line for each interval
@@ -3797,20 +3797,27 @@ function drawRulerMarking(sequencePosition, xCoordinate, align) {
     .attr("stroke", "black")
 }
 
+/// Draw ruler markings for the given requested region.
+///
+/// The requested region should be an array of 2 items, each of which is an
+/// array of a sequence position and an image X coordinate. If the array is not
+/// 2 items, no connecting line is drawn.
 function drawRulerMarkingRegion(ticks_region) {
   // Each tick is a base coordinate and an image coordinate
   ticks_region.forEach((tick) => drawRulerMarkingEndpoint(tick[0], tick[1]));
   
   let lineY = minYCoordinate - NODE_MARGIN - 6;
 
-  svg
-    .append("line")
-    .attr("x1", ticks_region[0][1])
-    .attr("y1", lineY)
-    .attr("x2", ticks_region[1][1])
-    .attr("y2", lineY)
-    .attr("stroke-width", 4)
-    .attr("stroke", "#FFFE3A");
+  if (ticks_region && ticks_region.length == 2) {
+    svg
+      .append("line")
+      .attr("x1", ticks_region[0][1])
+      .attr("y1", lineY)
+      .attr("x2", ticks_region[1][1])
+      .attr("y2", lineY)
+      .attr("stroke-width", 4)
+      .attr("stroke", "#FFFE3A");
+  }
 }
 
 function drawRulerMarkingEndpoint(sequencePosition, xCoordinate) {

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -3808,7 +3808,7 @@ function drawRulerMarkingRegion(ticks_region) {
   
   let lineY = minYCoordinate - NODE_MARGIN - 6;
 
-  if (ticks_region && ticks_region.length == 2) {
+  if (ticks_region && ticks_region.length === 2) {
     svg
       .append("line")
       .attr("x1", ticks_region[0][1])

--- a/src/util/tubemap.js
+++ b/src/util/tubemap.js
@@ -3716,7 +3716,7 @@ function drawRuler() {
   ticks = separatedTicks;
 
   // plot ticks highlighting the region
-  ticks_region.forEach((tick) => drawRulerMarkingRegion(tick[0], tick[1]));
+  drawRulerMarkingRegion(ticks_region);
 
   // draw horizontal line for each interval
   
@@ -3797,14 +3797,38 @@ function drawRulerMarking(sequencePosition, xCoordinate, align) {
     .attr("stroke", "black")
 }
 
-function drawRulerMarkingRegion(sequencePosition, xCoordinate) {
+function drawRulerMarkingRegion(ticks_region) {
+  // Each tick is a base coordinate and an image coordinate
+  ticks_region.forEach((tick) => drawRulerMarkingEndpoint(tick[0], tick[1]));
+  
+  let lineY = minYCoordinate - NODE_MARGIN - 6;
+
   svg
-    .append("circle")
-    .attr("cx", xCoordinate + 3)
-    .attr("cy", minYCoordinate - 13)
-    .attr("r", 10)
-    .attr("opacity", 0.5)
-    .attr("fill", "yellow")
+    .append("line")
+    .attr("x1", ticks_region[0][1])
+    .attr("y1", lineY)
+    .attr("x2", ticks_region[1][1])
+    .attr("y2", lineY)
+    .attr("stroke-width", 4)
+    .attr("stroke", "#FFFE3A");
+}
+
+function drawRulerMarkingEndpoint(sequencePosition, xCoordinate) {
+  
+  let pointX = xCoordinate;
+  let pointY = minYCoordinate - NODE_MARGIN - 1;
+  let arrowWidth = 8;
+  let arrowHeight = 10;
+
+  svg
+    .append("path")
+    .attr("d", `M${pointX - arrowWidth} ${pointY - arrowHeight}`
+      + ` L${pointX} ${pointY}`
+      + ` L${pointX + arrowWidth} ${pointY - arrowHeight}`
+    )
+    .attr("stroke-width", 0)
+    .attr("fill", "#FFFE3A")
+    .attr("stroke", "none")
     .style("pointer-events", "none");
 }
 


### PR DESCRIPTION
This improves(?) the requested region marker so you can actually see the between-base locations, and runs a bar along the selected region.

Here's `ref:0-2` in `cactus.vg`
<img width="499" height="262" alt="Screenshot 2025-08-14 at 16 34 47" src="https://github.com/user-attachments/assets/aebae170-c55e-4f08-9425-b7e0d0998e39" />
We have two yellow triangles at the inter-base locations marking the bounds of the requested 0-based end-exclusive region, and a yellow line connecting them. They're also a slightly easier to see yellow than the circles were.

The region indicator, previously and now, matches the BED convention of 0-based, end-exclusive coordinates. But vg is still using 0-based, end-inclusive coordinates to fetch the graph.

I've also restored the scale bar for the Lancet examples, and anything else generated before vg's real subpath support, fixing a regression I made in 3aa66ddf9041135c8c4f404864120506e350031d. But the Lancet BEDs are non-standardly 1-based (and I think also end-inclusive?), and the provided graphs are describing end-inclusive regions, so when looking at the Lancet examples the coordinates are not using the same convention as usual, and so the region amrker ends a base before the displayed graph.

We can sort out the varying coordinate conventions in a proper solution for #488, which isn't this.